### PR TITLE
Test NumPy 1.12 and latest in both Travis and tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ matrix:
     - python: 2.7
     - python: 3.6
 
+env:
+  - NUMPY=1.12
+  - NUMPY=*
+
 install:
   # Install conda
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -16,7 +20,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n test-sparse python=$TRAVIS_PYTHON_VERSION pytest numpy scipy flake8 nomkl
+  - conda create -n test-sparse python=$TRAVIS_PYTHON_VERSION pytest numpy=$NUMPY scipy flake8 nomkl
   - source activate test-sparse
 
   - pip install -e .[tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ sudo: False
 
 language: python
 
-matrix:
-  include:
-    - python: 2.7
-    - python: 3.6
+python:
+  - 2.7
+  - 3.6
 
 env:
   - NUMPY=1.12

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,13 @@
 [tox]
-envlist = py27,py36
+envlist = {py27,py36}-{numpy12,numpylatest}
 [testenv]
+deps =
+    numpy12: numpy==1.12.0
+basepython =
+    py27: python2.7
+    py36: python3.6
 commands=
+    pip list
     py.test {posargs}
 extras=
     docs


### PR DESCRIPTION
I have now run into issues with NumPy 1.12 twice: #71 #78. Maybe it makes sense to test multiple Python versions and multiple NumPy versions?

This PR creates a testmatrix in both Travis and tox that tests all combinations of

 - Python 2.7
 - Python 3.6

and

 - NumPy 1.12.0
 - NumPy latest

In tox you can run a specific test on a version combination using

    tox -e py36-numpy12 -- -k testname

for `testname` on Python 3.6 and NumPy 1.12.0