### PR TITLE
Add densification manager.

### DIFF
--- a/sparse/coo.py
+++ b/sparse/coo.py
@@ -2043,11 +2043,9 @@ class COO(SparseArray):
         return self.elemwise(np.ndarray.astype, dtype)
 
     @contextmanager
-    def configure_densification(self, densify, max_size=None, min_density=None):
+    def configure_densification(self, **kwargs):
         old_densification_config = self.densification_config
-        self.densification_config = DensificationConfig(densify=densify,
-                                                        max_size=max_size,
-                                                        min_density=min_density)
+        self.densification_config = DensificationConfig(**kwargs)
 
         yield
 

--- a/sparse/densification.py
+++ b/sparse/densification.py
@@ -1,0 +1,118 @@
+import sys
+from numbers import Integral, Number
+from collections import Iterable
+
+import numpy as np
+
+from .utils import _get_broadcast_shape, SparseArray
+
+try:  # Windows compatibility
+    int = long
+except NameError:
+    pass
+
+try:
+    _max_size = sys.maxsize
+except NameError:
+    _max_size = sys.maxint
+
+
+class DensificationConfig(object):
+    def __init__(self, densify=None, max_size=None, min_density=None):
+        if isinstance(densify, DensificationConfig):
+            self.densify = densify.densify
+            self.max_size = densify.max_size
+            self.min_density = densify.min_density
+            return
+
+        if max_size is None:
+            max_size = 10000
+
+        if min_density is None:
+            min_density = 0.25
+
+        if not isinstance(densify, bool) and densify is not None:
+            raise ValueError('always_densify must be a bool or None.')
+
+        if not isinstance(max_size, Integral) or max_size < 0:
+            raise ValueError("max_nnz must be a non-negative integer.")
+
+        if not isinstance(min_density, Number) or not (0.0 <= min_density <= 1.0):
+            raise ValueError('min_density must be a number between 0 and 1.')
+
+        self.densify = densify
+        self.max_size = int(max_size)
+        self.min_density = float(min_density)
+
+    def _should_densify(self, size, density):
+        if self.densify:
+            return True
+        elif self.densify is False:
+            return False
+        else:
+            return self.max_size >= size or self.min_density <= density
+
+    def _raise_if_fails(self, size, density, name):
+        if not self._should_densify(size, density):
+            raise ValueError("Performing this operation would produce "
+                             "a dense result: %s" % name)
+
+    def check(self, name, *arrays):
+        result_shape = ()
+        density = 1.0
+
+        for arr in arrays:
+            if isinstance(arr, SparseArray):
+                density = min(density, arr.density)
+                result_shape = _get_broadcast_shape(result_shape, arr.shape)
+
+        size = np.prod(result_shape, dtype=np.uint64)
+
+        self._raise_if_fails(size, density, name)
+
+    @staticmethod
+    def validate(configs):
+        if isinstance(configs, Iterable):
+            for config in configs:
+                DensificationConfig.validate(config)
+
+            return
+
+        if not isinstance(configs, DensificationConfig):
+            raise ValueError('Invalid DensificationConfig.')
+
+    @staticmethod
+    def combine(*configs):
+        result = set()
+
+        for config in configs:
+            if isinstance(config, Iterable):
+                DensificationConfig.validate(config)
+                result.update(config)
+            elif isinstance(config, DensificationConfig):
+                DensificationConfig.validate(config)
+                result.add(config)
+
+        return result
+
+    @staticmethod
+    def from_many(managers):
+        densify = True
+        max_size = _max_size
+        min_density = 1.0
+
+        for manager in managers:
+            densify = _three_way_and(densify, manager.densify)
+            max_size = max(max_size, manager.max_size)
+            min_density = min(min_density, manager.min_density)
+
+        return DensificationConfig(densify, max_size, min_density)
+
+
+def _three_way_and(flag1, flag2):
+    if flag1:
+        return flag2
+    elif flag1 is None:
+        return False if flag2 is False else None
+    else:
+        return False

--- a/sparse/densification.py
+++ b/sparse/densification.py
@@ -118,10 +118,17 @@ class DensificationConfig(object):
 
         for manager in managers:
             densify = _three_way_and(densify, manager.densify)
-            max_size = max(max_size, manager.max_size)
+            max_size = min(max_size, manager.max_size)
             min_density = max(min_density, manager.min_density)
 
         return DensificationConfig(densify, max_size, min_density)
+
+    def __str__(self):
+        if isinstance(self.densify, bool):
+            return '<DensificationConfig: densify=%s>' % self.densify
+        else:
+            return '<DensificationConfig: max_size=%s, min_density=%s>' % \
+                   (self.max_size, self.min_density)
 
 
 def _three_way_and(flag1, flag2):

--- a/sparse/dok.py
+++ b/sparse/dok.py
@@ -10,7 +10,7 @@ from numbers import Integral
 from collections import Iterable
 
 from .slicing import normalize_index
-from .utils import _zero_of_dtype
+from .utils import _zero_of_dtype, SparseArray
 
 try:  # Windows compatibility
     int = long
@@ -18,7 +18,7 @@ except NameError:
     pass
 
 
-class DOK(object):
+class DOK(SparseArray):
     """
     A class for building sparse multidimensional arrays.
 
@@ -341,6 +341,8 @@ class DOK(object):
 
         if value != _zero_of_dtype(self.dtype):
             self.data[tuple(key_list)] = value[()]
+        else:
+            self.data.pop(tuple(key_list), None)
 
     def __str__(self):
         return "<DOK: shape=%s, dtype=%s, nnz=%d>" % (self.shape, self.dtype, self.nnz)

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1155,6 +1155,7 @@ def test_densification_config(func, kwargs):
     lambda s1, s2: -(s1 - s2),
 ])
 @pytest.mark.parametrize('kwargs', [
+    {'densify': False},
     {'densify': True},
     {
         'densify': None,
@@ -1164,6 +1165,11 @@ def test_densification_config(func, kwargs):
     {
         'densify': None,
         'max_size': 25,
+        'min_density': 0.7,
+    },
+    {
+        'densify': None,
+        'max_size': 0,
         'min_density': 0.7,
     },
 ])
@@ -1194,3 +1200,26 @@ def test_densification_config_sparse(func, kwargs):
         s1._densification_config,
         s2._densification_config,
     ])
+
+
+@pytest.mark.parametrize('func', [
+    lambda s1, s2: np.exp(s1),
+    lambda s1, s2: np.cos(s1),
+    lambda s1, s2: s1 + 1
+])
+@pytest.mark.parametrize('kwargs', [
+    {'densify': False},
+    {
+        'densify': None,
+        'max_size': 0,
+        'min_density': 0.7,
+    },
+])
+def test_densification_config_fails(func, kwargs):
+    s1 = sparse.random((2, 3, 4), density=0.5)
+    s2 = sparse.random((2, 3, 4), density=0.5)
+
+    with s1.configure_densification(**kwargs), \
+         s2.configure_densification(**kwargs), \
+         pytest.raises(ValueError):
+        func(s1, s2)

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1189,18 +1189,6 @@ def test_densification_config_sparse(func, kwargs):
         assert isinstance(func_s, COO)
         assert_eq(func_x, func_s)
 
-        assert isinstance(func_s._densification_config, set)
-
-        assert func_s._densification_config.issubset([
-            s1._densification_config,
-            s2._densification_config,
-        ])
-
-    assert func_s._densification_config.issubset([
-        s1._densification_config,
-        s2._densification_config,
-    ])
-
 
 @pytest.mark.parametrize('func', [
     lambda s1, s2: np.exp(s1),

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1085,8 +1085,8 @@ def test_scalar_shape_construction():
 
 
 def test_len():
-    s = sparse.random((20, 30, 40))
-    assert len(s) == 20
+    s = sparse.random((2, 3, 4))
+    assert len(s) == 2
 
 
 def test_density():
@@ -1095,12 +1095,102 @@ def test_density():
 
 
 def test_size():
-    s = sparse.random((20, 30, 40))
-    assert s.size == 20 * 30 * 40
+    s = sparse.random((2, 3, 4))
+    assert s.size == 2 * 3 * 4
 
 
 def test_np_array():
-    s = sparse.random((20, 30, 40))
-    x = np.array(s)
+    s = sparse.random((2, 3, 4))
+    with s.configure_densification(densify=True):
+        x = np.array(s)
     assert isinstance(x, np.ndarray)
     assert_eq(x, s)
+
+
+@pytest.mark.parametrize('func', [
+    lambda s1, s2: np.exp(s1),
+    lambda s1, s2: np.cos(s1),
+    lambda s1, s2: s1 + 1,
+    lambda s1, s2: s1 + s2 + 1,
+    lambda s1, s2: -(s1 + s2) + 1,
+])
+@pytest.mark.parametrize('kwargs', [
+    {'densify': True},
+    {
+        'densify': None,
+        'max_size': 0,
+        'min_density': 0.3,
+    },
+    {
+        'densify': None,
+        'max_size': 25,
+        'min_density': 0.7,
+    },
+])
+def test_densification_config(func, kwargs):
+    s1 = sparse.random((2, 3, 4), density=0.5)
+    s2 = sparse.random((2, 3, 4), density=0.5)
+
+    x1 = s1.todense()
+    x2 = s2.todense()
+
+    func_x = func(x1, x2)
+
+    with s1.configure_densification(**kwargs), \
+         s2.configure_densification(**kwargs):
+        func_s = func(s1, s2)
+
+        assert isinstance(func_s, np.ndarray)
+        assert_eq(func_x, func_s)
+
+    with pytest.raises(ValueError):
+        func(s1, s2)
+
+
+@pytest.mark.parametrize('func', [
+    lambda s1, s2: np.sin(s1),
+    lambda s1, s2: np.expm1(s1),
+    lambda s1, s2: s1 + 0,
+    lambda s1, s2: s1 + s2,
+    lambda s1, s2: -(s1 - s2),
+])
+@pytest.mark.parametrize('kwargs', [
+    {'densify': True},
+    {
+        'densify': None,
+        'max_size': 0,
+        'min_density': 0.3,
+    },
+    {
+        'densify': None,
+        'max_size': 25,
+        'min_density': 0.7,
+    },
+])
+def test_densification_config_sparse(func, kwargs):
+    s1 = sparse.random((2, 3, 4), density=0.5)
+    s2 = sparse.random((2, 3, 4), density=0.5)
+
+    x1 = s1.todense()
+    x2 = s2.todense()
+
+    func_x = func(x1, x2)
+
+    with s1.configure_densification(**kwargs), \
+         s2.configure_densification(**kwargs):
+        func_s = func(s1, s2)
+
+        assert isinstance(func_s, COO)
+        assert_eq(func_x, func_s)
+
+        assert isinstance(func_s._densification_config, set)
+
+        assert func_s._densification_config.issubset([
+            s1._densification_config,
+            s2._densification_config,
+        ])
+
+    assert func_s._densification_config.issubset([
+        s1._densification_config,
+        s2._densification_config,
+    ])

--- a/sparse/utils.py
+++ b/sparse/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numbers import Integral
+from functools import total_ordering
 from abc import ABCMeta
 
 from six.moves import range, zip_longest
@@ -30,6 +31,36 @@ def assert_eq(x, y, **kwargs):
     else:
         yy = y
     assert np.allclose(xx, yy, **kwargs)
+
+
+# (c) kindall
+# Taken from https://stackoverflow.com/a/9504358/774273
+# License: https://creativecommons.org/licenses/by-sa/3.0/
+@total_ordering
+class TriState(object):
+    def __init__(self, value=None):
+        if any(value is v for v in (True, False, None)):
+            self.value = value
+        else:
+            raise ValueError("Tristate value must be True, False, or None")
+
+    def __eq__(self, other):
+        return (self.value is other.value if isinstance(other, TriState)
+        else self.value is other)
+
+    def __le__(self, other):
+        if self.value is False:
+            return True
+        elif self.value is None:
+            return other.value is not False
+        else:
+            return other.value is True
+
+    def __str__(self):
+        return str(self.value)
+
+    def __repr__(self):
+        return "Tristate(%s)" % self.value
 
 
 def is_lexsorted(x):

--- a/sparse/utils.py
+++ b/sparse/utils.py
@@ -1,5 +1,12 @@
 import numpy as np
 from numbers import Integral
+from abc import ABCMeta
+
+from six.moves import range, zip_longest
+
+
+class SparseArray(object):
+    __metaclass__ = ABCMeta
 
 
 def assert_eq(x, y, **kwargs):
@@ -146,3 +153,36 @@ def random(
         ar = DOK(ar)
 
     return ar
+
+
+def _get_broadcast_shape(shape1, shape2, is_result=False):
+    """
+    Get the overall broadcasted shape.
+
+    Parameters
+    ----------
+    shape1, shape2 : tuple[int]
+        The input shapes to broadcast together.
+    is_result : bool
+        Whether or not shape2 is also the result shape.
+
+    Returns
+    -------
+    result_shape : tuple[int]
+        The overall shape of the result.
+
+    Raises
+    ------
+    ValueError
+        If the two shapes cannot be broadcast together.
+    """
+    # https://stackoverflow.com/a/47244284/774273
+    if not all((l1 == l2) or (l1 == 1) or ((l2 == 1) and not is_result) for l1, l2 in
+               zip(shape1[::-1], shape2[::-1])):
+        raise ValueError('operands could not be broadcast together with shapes %s, %s' %
+                         (shape1, shape2))
+
+    result_shape = tuple(max(l1, l2) for l1, l2 in
+                         zip_longest(shape1[::-1], shape2[::-1], fillvalue=1))[::-1]
+
+    return result_shape


### PR DESCRIPTION
Fixes #10

A densification manager for `COO`.

You can do, for example,

```
with s.configure_densification(densify=True), s2.configure_densification(densify=True):
    x = np.exp(s)
    x2 = s + 1
    x3 = -(s + s2) + 1
```

And it should work automagically.