### PR TITLE
Enhance dot + tests.

### DIFF
--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -288,6 +288,6 @@ All of the following will raise an :obj:`IndexError`, like in Numpy 1.13 and lat
 Other Operations
 ----------------
 :obj:`COO` arrays support a number of other common operations. Among them are
-:obj:`dot`, :obj:`tensordot`, :obj:`concatenate` and :obj:`stack`,
-:obj:`COO.transpose` and :obj:`COO.reshape`. You can view the full list on the
-API reference page for :obj:`sparse`
+:obj:`dot <COO.dot>`, :obj:`tensordot <COO.tensordot>`, :obj:`concatenate <COO.concatenate>`
+and :obj:`stack <COO.stack>`, :obj:`COO.transpose <COO.transpose>` and :obj:`reshape <COO.reshape>`.
+You can view the full list on the API reference page for :obj:`sparse`.

--- a/sparse/coo.py
+++ b/sparse/coo.py
@@ -1738,7 +1738,17 @@ def dot(a, b):
         raise NotImplementedError(
             "Cannot perform dot product on types %s, %s" %
             (type(a), type(b)))
-    return tensordot(a, b, axes=((a.ndim - 1,), (b.ndim - 2,)))
+
+    if a.ndim == 1 and b.ndim == 1:
+        return (a * b).sum()
+
+    a_axis = -1
+    b_axis = -2
+
+    if b.ndim == 1:
+        b_axis = -1
+
+    return tensordot(a, b, axes=(a_axis, b_axis))
 
 
 def _dot(a, b):

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -166,7 +166,6 @@ def test_tensordot(a_shape, b_shape, axes):
     ((5,), (5,)),
 ])
 def test_dot(a_shape, b_shape):
-    import operator
     sa = sparse.random(a_shape, density=0.5)
     sb = sparse.random(b_shape, density=0.5)
 

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -158,10 +158,17 @@ def test_tensordot(a_shape, b_shape, axes):
     # assert isinstance(sparse.tensordot(a, sb, axes), COO)
 
 
-def test_dot():
+@pytest.mark.parametrize('a_shape, b_shape', [
+    ((3, 4, 5), (5, 6)),
+    ((4, 5), (5, 6)),
+    ((5,), (5, 6)),
+    ((4, 5), (5,)),
+    ((5,), (5,)),
+])
+def test_dot(a_shape, b_shape):
     import operator
-    sa = sparse.random((3, 4, 5), density=0.5)
-    sb = sparse.random((5, 6), density=0.5)
+    sa = sparse.random(a_shape, density=0.5)
+    sb = sparse.random(b_shape, density=0.5)
 
     a = sa.todense()
     b = sb.todense()


### PR DESCRIPTION
Fixes #95 
Do a little work on `dot` to bring it up to par with `np.dot`.

- Support mixed matrix-vector products (returning a 1-D array).
- Support vector-vector products (returning a scalar).