### PR TITLE
Add N-ary broadcasting operations.

### DIFF
--- a/docs/generated/sparse.COO.elemwise.rst
+++ b/docs/generated/sparse.COO.elemwise.rst
@@ -1,6 +1,0 @@
-COO\.elemwise
-=============
-
-.. currentmodule:: sparse
-
-.. automethod:: COO.elemwise

--- a/docs/generated/sparse.COO.rst
+++ b/docs/generated/sparse.COO.rst
@@ -31,7 +31,6 @@ COO
    .. autosummary::
       :toctree:
 
-      COO.elemwise
       COO.astype
       COO.round
 

--- a/docs/generated/sparse.elemwise.rst
+++ b/docs/generated/sparse.elemwise.rst
@@ -1,0 +1,6 @@
+elemwise
+========
+
+.. currentmodule:: sparse
+
+.. autofunction:: elemwise

--- a/docs/generated/sparse.rst
+++ b/docs/generated/sparse.rst
@@ -27,6 +27,8 @@ API
 
     dot
 
+    elemwise
+
     random
 
     stack

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -33,16 +33,20 @@ or numpy functions that are not yet implemented for sparse arrays
 
 This page describes those valid operations, and their limitations.
 
-:obj:`COO.elemwise`
+:obj:`elemwise`
 ~~~~~~~~~~~~~~~~~~~
 This function allows you to apply any arbitrary unary or binary function where
 the first object is :obj:`COO`, and the second is a scalar, :obj:`COO`, or
-a :doc:`Numpy arrays <reference/generated/numpy.ndarray>`. For example, the
+a :obj:`scipy.sparse.spmatrix`. For example, the
 following will add two :obj:`COO` objects:
 
 .. code-block:: python
 
-   x.elemwise(np.add, y)
+   sparse.elemwise(np.add, x, y)
+
+
+.. note:: Previously, :obj:`elemwise` was a method of the :obj:`COO` class. Now,
+   it has been moved to the :obj:`sparse` module.
 
 .. _operations-auto-densification:
 
@@ -78,26 +82,8 @@ If densification is needed, it must be explicit. In other words, you must call
 :obj:`COO.todense` on the :obj:`COO` object. If both operands are :obj:`COO`,
 both must be densified.
 
-
-Operations with :doc:`Numpy arrays <reference/generated/numpy.ndarray>`
------------------------------------------------------------------------
-Certain operations with :obj:`numpy.ndarray` are also supported. For example,
-the following are all allowed if :code:`x` is a :obj:`numpy.ndarray` and
-:code:`(x == 0).all()` evaluates to :code:`True`:
-
-.. code-block:: python
-
-   x + y
-   x - y
-
-The following is true so long as there are no infinities or NaNs in :code:`x`:
-
-.. code-block:: python
-
-   x * y
-
-In general, if operating on the :code:`numpy.ndarray` with a zero would produce
-all-zeros then the operation is supported.
+.. note:: Previously, operations with Numpy arrays were sometimes supported. Now,
+   it is necessary to convert Numpy arrays to :obj:`COO` objects.
 
 
 Operations with :obj:`scipy.sparse.spmatrix`

--- a/sparse/__init__.py
+++ b/sparse/__init__.py
@@ -1,4 +1,4 @@
-from .coo import COO, tensordot, concatenate, stack, dot, triu, tril
+from .coo import COO, elemwise, tensordot, concatenate, stack, dot, triu, tril
 from .dok import DOK
 from .sparse_array import SparseArray
 from .utils import random

--- a/sparse/coo.py
+++ b/sparse/coo.py
@@ -2132,7 +2132,7 @@ def _match_coo(*args, **kwargs):
         raise ValueError('Unknown kwargs %s' % kwargs.keys())
 
     if return_midx and (len(args) != 2 or cache is not None):
-        raise NotImplementedError('Matching only supported for two args, and no cache.')
+        raise NotImplementedError('Matching indices only supported for two args, and no cache.')
 
     matched_arrays = [args[0]]
     cache_key = [id(args[0])]
@@ -2156,8 +2156,13 @@ def _match_coo(*args, **kwargs):
         linear = [_linear_loc(rc, reduced_shape) for rc in reduced_coords]
         sorted_idx = [np.argsort(idx) for idx in linear]
         linear = [idx[s] for idx, s in zip(linear, sorted_idx)]
-        coords = [arg.coords[:, s] for arg, s in zip(cargs, sorted_idx)]
         matched_idx = _match_arrays(*linear)
+
+        if return_midx:
+            matched_idx = [sidx[midx] for sidx, midx in zip(sorted_idx, matched_idx)]
+            return matched_idx
+
+        coords = [arg.coords[:, s] for arg, s in zip(cargs, sorted_idx)]
         mcoords = [c[:, idx] for c, idx in zip(coords, matched_idx)]
         mcoords = _get_matching_coords(mcoords, params, current_shape)
         mdata = [arg.data[sorted_idx[0]][matched_idx[0]] for arg in matched_arrays]
@@ -2166,10 +2171,6 @@ def _match_coo(*args, **kwargs):
 
         if cache is not None:
             cache[key] = matched_arrays
-
-        if return_midx:
-            matched_idx = [sidx[midx] for sidx, midx in zip(sorted_idx, matched_idx)]
-            return matched_idx
 
     return matched_arrays
 

--- a/sparse/coo.py
+++ b/sparse/coo.py
@@ -1894,39 +1894,6 @@ def tril(x, k=0):
     return COO(coords, data, x.shape, x.has_duplicates, x.sorted)
 
 
-def _nary_match(*arrays):
-    """
-    Matches coordinates from N different 1-D arrays. Equivalent to
-    an SQL outer join.
-
-    Parameters
-    ----------
-    arrays : tuple[numpy.ndarray]
-        Input arrays to match, must be sorted.
-
-    Returns
-    -------
-    matched : numpy.ndarray
-        The overall matched array.
-
-    matched_idx : list[numpy.ndarray]
-        The indices for the matched coordinates in each array.
-    """
-    import pdb; pdb.set_trace()
-
-    matched = arrays[0]
-    matched_idx = [np.arange(arrays[0].shape[0],
-                             dtype=np.min_scalar_type(arrays[0].shape[0] - 1))]
-
-    for arr in arrays[1:]:
-        old_idx, new_idx = _match_arrays(matched, arr)
-        matched = matched[old_idx]
-        matched_idx = [idx[old_idx] for idx in matched_idx]
-        matched_idx.append(new_idx)
-
-    return matched, matched_idx
-
-
 # (c) Paul Panzer
 # Taken from https://stackoverflow.com/a/47833496/774273
 # License: https://creativecommons.org/licenses/by-sa/3.0/

--- a/sparse/coo.py
+++ b/sparse/coo.py
@@ -2120,6 +2120,7 @@ def _elemwise_n_ary(func, *args, **kwargs):
 def _match_coo(*args):
     """
     Matches the coordinates for any number of input :obj:`COO` arrays.
+    Equivalent to "sparse" broadcasting for all arrays.
 
     Parameters
     ----------
@@ -2129,12 +2130,11 @@ def _match_coo(*args):
     Returns
     -------
     matched_idx : list[ndarray]
-        The indices of matched elements.
-    matched_coords : list[ndarray]
-        The matched coordinates.
-    matched_data : list[ndarray]
-        The matched data.
+        The indices of matched elements in the original arrays.
+    matched_arrays : list[COO]
+        The expanded, matched :obj:`COO` objects.
     """
+    # If there's only a single input, return as-is.
     if len(args) == 1:
         return [np.arange(args[0].nnz)], [args[0]]
 
@@ -2179,6 +2179,8 @@ def _match_coo(*args):
 def _unmatch_coo(func, args, mask, **kwargs):
     """
     Matches the coordinates for any number of input :obj:`COO` arrays.
+
+    First computes the matches, then filters out the non-matches.
 
     Parameters
     ----------

--- a/sparse/coo.py
+++ b/sparse/coo.py
@@ -2213,10 +2213,10 @@ def _unmatch_coo(func, args, mask, cache, **kwargs):
     partial = PositinalArgumentPartial(func, pos, posargs)
     matched_func = partial(*[a.data for a in matched_arrays], **kwargs)
 
-    if (matched_func == _zero_of_dtype(matched_func.dtype)).all():
-        return [], []
-
     unmatched_mask = matched_func != _zero_of_dtype(matched_func.dtype)
+
+    if not unmatched_mask.any():
+        return [], []
 
     func_data = matched_func[unmatched_mask]
     func_coords = matched_arrays[0].coords[:, unmatched_mask]

--- a/sparse/coo.py
+++ b/sparse/coo.py
@@ -1912,6 +1912,7 @@ def _nary_match(*arrays):
     matched_idx : list[numpy.ndarray]
         The indices for the matched coordinates in each array.
     """
+    import pdb; pdb.set_trace()
 
     matched = arrays[0]
     matched_idx = [np.arange(arrays[0].shape[0],

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -416,7 +416,8 @@ def test_sparse_broadcasting(monkeypatch):
 
     xs * ys
 
-    assert state['num_matches'] == 1
+    # Less than in case there's absolutely no overlap in some cases.
+    assert state['num_matches'] <= 1
 
 
 def test_dense_broadcasting(monkeypatch):
@@ -436,7 +437,8 @@ def test_dense_broadcasting(monkeypatch):
 
     xs + ys
 
-    assert state['num_matches'] == 3
+    # Less than in case there's absolutely no overlap in some cases.
+    assert state['num_matches'] <= 3
 
 
 @pytest.mark.parametrize('format', ['coo', 'dok'])

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -235,6 +235,25 @@ def test_elemwise_binary(func, shape):
 
 
 @pytest.mark.parametrize('func', [
+    lambda x, y, z: x + y + z,
+    lambda x, y, z: x * y * z,
+    lambda x, y, z: x + y * z,
+    lambda x, y, z: (x + y) * z
+])
+@pytest.mark.parametrize('shape', [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)])
+def test_elemwise_trinary(func, shape):
+    xs = sparse.random(shape, density=0.5)
+    ys = sparse.random(shape, density=0.5)
+    zs = sparse.random(shape, density=0.5)
+
+    x = xs.todense()
+    y = ys.todense()
+    z = zs.todense()
+
+    assert_eq(sparse.elemwise(func, xs, ys, zs), func(x, y, z))
+
+
+@pytest.mark.parametrize('func', [
     operator.pow, operator.truediv, operator.floordiv,
     operator.ge, operator.le, operator.eq, operator.mod
 ])
@@ -290,7 +309,7 @@ def test_elemwise_scalar(func, scalar, convert_to_np_number):
     (operator.le, 3),
     (operator.eq, 1),
 ])
-@pytest.mark.parametrize('convert_to_np_number', [True, False])
+@pytest.mark.parametrize('convert_to_np_number', [True])
 def test_leftside_elemwise_scalar(func, scalar, convert_to_np_number):
     xs = sparse.random((2, 3, 4), density=0.5)
     if convert_to_np_number:

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -309,7 +309,7 @@ def test_elemwise_scalar(func, scalar, convert_to_np_number):
     (operator.le, 3),
     (operator.eq, 1),
 ])
-@pytest.mark.parametrize('convert_to_np_number', [True])
+@pytest.mark.parametrize('convert_to_np_number', [True, False])
 def test_leftside_elemwise_scalar(func, scalar, convert_to_np_number):
     xs = sparse.random((2, 3, 4), density=0.5)
     if convert_to_np_number:

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -25,7 +25,7 @@ def test_reductions(reduction, axis, keepdims, kwargs, eqkwargs):
     y = x.todense()
     xx = getattr(x, reduction)(axis=axis, keepdims=keepdims, **kwargs)
     yy = getattr(y, reduction)(axis=axis, keepdims=keepdims, **kwargs)
-    assert_eq(xx, yy, **eqkwargs)
+    assert_eq(xx, yy, check_nnz=False, **eqkwargs)
 
 
 @pytest.mark.parametrize('reduction,kwargs,eqkwargs', [
@@ -42,7 +42,7 @@ def test_ufunc_reductions(reduction, axis, keepdims, kwargs, eqkwargs):
     y = x.todense()
     xx = reduction(x, axis=axis, keepdims=keepdims, **kwargs)
     yy = reduction(y, axis=axis, keepdims=keepdims, **kwargs)
-    assert_eq(xx, yy, **eqkwargs)
+    assert_eq(xx, yy, check_nnz=False, **eqkwargs)
 
 
 @pytest.mark.parametrize('axis', [
@@ -713,7 +713,7 @@ def test_canonical():
                        [1, 0, 3],
                        [0, 1, 0],
                        [1, 0, 3]]).T
-    data = np.arange(5)
+    data = np.arange(5) + 1
 
     old = COO(coords, data, shape=(2, 2, 5))
     x = COO(coords, data, shape=(2, 2, 5))
@@ -922,13 +922,13 @@ def test_scipy_sparse_interface():
     x = scipy.sparse.coo_matrix(inp)
     xx = sparse.COO(inp)
 
-    assert_eq(x, xx)
-    assert_eq(x.T, xx.T)
-    assert_eq(xx.to_scipy_sparse(), x)
-    assert_eq(COO.from_scipy_sparse(xx.to_scipy_sparse()), xx)
+    assert_eq(x, xx, check_nnz=False)
+    assert_eq(x.T, xx.T, check_nnz=False)
+    assert_eq(xx.to_scipy_sparse(), x, check_nnz=False)
+    assert_eq(COO.from_scipy_sparse(xx.to_scipy_sparse()), xx, check_nnz=False)
 
-    assert_eq(x, xx)
-    assert_eq(x.T.dot(x), xx.T.dot(xx))
+    assert_eq(x, xx, check_nnz=False)
+    assert_eq(x.T.dot(x), xx.T.dot(xx), check_nnz=False)
     assert isinstance(x + xx, COO)
     assert isinstance(xx + x, COO)
 

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -491,48 +491,6 @@ def test_bitwise_binary_bool(func, shape):
     assert_eq(func(xs, ys), func(x, y))
 
 
-@pytest.mark.parametrize('func', [operator.mul])
-@pytest.mark.parametrize('shape', [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)])
-def test_numpy_mixed_binary(func, shape):
-    xs = sparse.random(shape, density=0.5)
-    y = np.random.rand(*shape)
-
-    x = xs.todense()
-
-    fs1 = func(xs, y)
-
-    assert isinstance(fs1, COO)
-    assert fs1.nnz <= xs.nnz
-    assert_eq(fs1, func(x, y))
-
-    fs2 = func(y, xs)
-
-    assert isinstance(fs2, COO)
-    assert fs2.nnz <= xs.nnz
-    assert_eq(fs2, func(y, x))
-
-
-@pytest.mark.parametrize('func', [operator.and_])
-@pytest.mark.parametrize('shape', [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)])
-def test_numpy_mixed_binary_bitwise(func, shape):
-    xs = (sparse.random(shape, density=0.5) * 100).astype(np.int_)
-    y = np.random.randint(100, size=shape)
-
-    x = xs.todense()
-
-    fs1 = func(xs, y)
-
-    assert isinstance(fs1, COO)
-    assert fs1.nnz <= xs.nnz
-    assert_eq(fs1, func(x, y))
-
-    fs2 = func(y, xs)
-
-    assert isinstance(fs2, COO)
-    assert fs2.nnz <= xs.nnz
-    assert_eq(fs2, func(y, x))
-
-
 def test_elemwise_binary_empty():
     x = COO({}, shape=(10, 10))
     y = sparse.random((10, 10), density=0.5)
@@ -796,29 +754,6 @@ def test_broadcasting(func, shape1, shape2):
 
     expected = func(x, y)
     actual = func(xs, ys)
-
-    assert_eq(expected, actual)
-
-    assert np.count_nonzero(expected) == actual.nnz
-
-
-@pytest.mark.parametrize('func', [operator.mul])
-@pytest.mark.parametrize('shape1,shape2', [((2, 3, 4), (3, 4)),
-                                           ((3, 4), (2, 3, 4)),
-                                           ((3, 1, 4), (3, 2, 4)),
-                                           ((1, 3, 4), (3, 4)),
-                                           ((3, 4, 1), (3, 4, 2)),
-                                           ((1, 5), (5, 1))])
-def test_numpy_mixed_broadcasting(func, shape1, shape2):
-    xs = sparse.random(shape1, density=0.5)
-    x = xs.todense()
-
-    y = np.random.rand(*shape2)
-
-    expected = func(x, y)
-    actual = func(xs, y)
-
-    assert isinstance(actual, COO)
 
     assert_eq(expected, actual)
 

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -325,6 +325,7 @@ def test_nary_broadcasting(shapes, func):
     np.inf,
     -np.inf
 ])
+@pytest.mark.filterwarnings('ignore:invalid value')
 def test_nary_broadcasting_pathological(shapes, func, value):
     def value_array(n):
         ar = np.empty((n,), dtype=np.float_)

--- a/sparse/utils.py
+++ b/sparse/utils.py
@@ -3,11 +3,10 @@ from numbers import Integral
 from collections import Iterable
 
 
-def assert_eq(x, y, **kwargs):
+def assert_eq(x, y, check_nnz=True, **kwargs):
     from .coo import COO
     assert x.shape == y.shape
     assert x.dtype == y.dtype
-    check_nnz = kwargs.pop('check_nnz', True)
 
     if isinstance(x, COO):
         if x.sorted:

--- a/sparse/utils.py
+++ b/sparse/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numbers import Integral
+from collections import Iterable
 
 
 def assert_eq(x, y, **kwargs):
@@ -151,3 +152,39 @@ def random(
 def isscalar(x):
     from .sparse_array import SparseArray
     return not isinstance(x, SparseArray) and np.isscalar(x)
+
+
+class PositinalArgumentPartial(object):
+    def __init__(self, func, pos, posargs):
+        if not isinstance(pos, Iterable):
+            pos = (pos,)
+            posargs = (posargs,)
+
+        n_partial_args = len(pos)
+
+        self.pos = pos
+        self.posargs = posargs
+        self.func = func
+
+        self.n = n_partial_args
+
+        self.__doc__ = func.__doc__
+
+    def __call__(self, *args, **kwargs):
+        j = 0
+        totargs = []
+
+        for i in range(len(args) + self.n):
+            if j >= self.n or i != self.pos[j]:
+                totargs.append(args[i - j])
+            else:
+                totargs.append(self.posargs[j])
+                j += 1
+
+        return self.func(*totargs, **kwargs)
+
+    def __str__(self):
+        return str(self.func)
+
+    def __repr__(self):
+        return repr(self.func)

--- a/sparse/utils.py
+++ b/sparse/utils.py
@@ -7,6 +7,7 @@ def assert_eq(x, y, **kwargs):
     from .coo import COO
     assert x.shape == y.shape
     assert x.dtype == y.dtype
+    check_nnz = kwargs.pop('check_nnz', True)
 
     if isinstance(x, COO):
         if x.sorted:
@@ -17,10 +18,14 @@ def assert_eq(x, y, **kwargs):
 
     if hasattr(x, 'todense'):
         xx = x.todense()
+        if check_nnz:
+            assert (xx != 0).sum() == x.nnz
     else:
         xx = x
     if hasattr(y, 'todense'):
         yy = y.todense()
+        if check_nnz:
+            assert (yy != 0).sum() == y.nnz
     else:
         yy = y
     assert np.allclose(xx, yy, **kwargs)

--- a/sparse/utils.py
+++ b/sparse/utils.py
@@ -146,3 +146,8 @@ def random(
         ar = DOK(ar)
 
     return ar
+
+
+def isscalar(x):
+    from .sparse_array import SparseArray
+    return not isinstance(x, SparseArray) and np.isscalar(x)


### PR DESCRIPTION
This PR adds N-ary broadcasting operations (in preparation for `where`) and simplifies code for the N-ary case.

Discussed in https://github.com/pydata/sparse/issues/1