### PR TITLE
Fix negative axis indices raising error, fixes #117

### DIFF
--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -8,6 +8,7 @@ import scipy.sparse
 from ..sparse_array import SparseArray
 from ..compatibility import range
 from ..utils import isscalar
+from .indexing import _normalize_axis
 
 
 def asCOO(x, name='asCOO', check=True):
@@ -230,8 +231,7 @@ def concatenate(arrays, axis=0):
     from .core import COO
 
     arrays = [x if isinstance(x, COO) else COO(x) for x in arrays]
-    if axis < 0:
-        axis = axis + arrays[0].ndim
+    axis = _normalize_axis(axis, arrays[0].ndim)
     assert all(x.shape[ax] == arrays[0].shape[ax]
                for x in arrays
                for ax in set(range(arrays[0].ndim)) - {axis})
@@ -281,8 +281,7 @@ def stack(arrays, axis=0):
 
     assert len(set(x.shape for x in arrays)) == 1
     arrays = [x if isinstance(x, COO) else COO(x) for x in arrays]
-    if axis < 0:
-        axis = axis + arrays[0].ndim + 1
+    axis = _normalize_axis(axis, arrays[0].ndim + 1)
     data = np.concatenate([x.data for x in arrays])
     coords = np.concatenate([x.coords for x in arrays], axis=1)
     shape = list(arrays[0].shape)

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -927,10 +927,9 @@ class COO(SparseArray, NDArrayOperatorsMixin):
             axes = list(reversed(range(self.ndim)))
 
         # Normalize all axe indices to posivite values
-        axes = np.array(axes)
-        axes[axes < 0] += self.ndim
+        axes = _normalize_axis(axes, self.ndim)
 
-        if np.any(axes >= self.ndim) or np.any(axes < 0):
+        if any(a >= self.ndim for a in axes) or any(a < 0 for a in axes):
             raise ValueError("invalid axis for this array")
 
         if len(np.unique(axes)) < len(axes):
@@ -940,10 +939,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
             raise ValueError("axes don't match array")
 
         # Normalize all axe indices to posivite values
-        try:
-            axes = np.arange(self.ndim)[list(axes)]
-        except IndexError:
-            raise ValueError("invalid axis for this array")
+        axes = _normalize_axis(axes, self.ndim)
 
         if len(np.unique(axes)) < len(axes):
             raise ValueError("repeated axis in transpose")
@@ -1484,7 +1480,6 @@ def _keepdims(original, new, axis):
     for ax in axis:
         shape[ax] = 1
     return new.reshape(shape)
-
 
 def _grouped_reduce(x, groups, method, **kwargs):
     """

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -1481,6 +1481,7 @@ def _keepdims(original, new, axis):
         shape[ax] = 1
     return new.reshape(shape)
 
+
 def _grouped_reduce(x, groups, method, **kwargs):
     """
     Performs a :code:`ufunc` grouped reduce.

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -5,7 +5,7 @@ import scipy.sparse
 from numpy.lib.mixins import NDArrayOperatorsMixin
 
 from .common import dot
-from .indexing import getitem
+from .indexing import getitem, _normalize_axis
 from .umath import elemwise, broadcast_to
 from ..compatibility import int, range
 from ..sparse_array import SparseArray
@@ -570,6 +570,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         >>> s.reduce(np.add)
         <COO: shape=(5,), dtype=int64, nnz=5, sorted=True, duplicates=False>
         """
+        axis = _normalize_axis(axis, self.ndim)
         zero_reduce_result = method.reduce([_zero_of_dtype(self.dtype)], **kwargs)
 
         if zero_reduce_result != _zero_of_dtype(np.dtype(zero_reduce_result)):

--- a/sparse/coo/indexing.py
+++ b/sparse/coo/indexing.py
@@ -472,6 +472,14 @@ def _normalize_axis(axis, ndim):
     if axis is None:
         return None
     if isinstance(axis, Iterable):
-        return tuple(ndim + a if a < 0 else a for a in axis)
+        axis = tuple(ndim + a if a < 0 else a for a in axis)
+        for a in axis:
+            if a >= ndim or a < 0:
+                raise ValueError(
+                    "Invalid axis index %d for ndim=%d" % (a, ndim)
+                )
+        return axis
+    elif isinstance(axis, int):
+        return _normalize_axis([axis], ndim)[0]
     else:
-        return ndim + axis if axis < 0 else axis
+        raise ValueError("axis %s not understood" % axis)

--- a/sparse/coo/indexing.py
+++ b/sparse/coo/indexing.py
@@ -450,3 +450,28 @@ def _join_adjacent_pairs(starts_old, stops_old):  # pragma: no cover
     stops.append(stops_old[-1])
 
     return starts, stops
+
+
+def _normalize_axis(axis, ndim):
+    """
+    Normalize negative axis indices to their positive counterpart for a given
+    number of dimensions.
+
+    Parameters
+    ----------
+    axis : Union[int, Iterable[int], None]
+        The axis indices.
+    ndim : int
+        Number of dimensions to normalize axis indices against.
+
+    Returns
+    -------
+    axis
+        The normalized axis indices.
+    """
+    if axis is None:
+        return None
+    if isinstance(axis, Iterable):
+        return tuple(ndim + a if a < 0 else a for a in axis)
+    else:
+        return ndim + axis if axis < 0 else axis

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -34,7 +34,7 @@ def test_reductions(reduction, axis, keepdims, kwargs, eqkwargs):
     (np.prod, {}, {}),
     (np.min, {}, {}),
 ])
-@pytest.mark.parametrize('axis', [None, 0, 1, 2, (0, 2)])
+@pytest.mark.parametrize('axis', [None, 0, 1, 2, (0, 2), -1, (0, -1)])
 @pytest.mark.parametrize('keepdims', [True, False])
 def test_ufunc_reductions(reduction, axis, keepdims, kwargs, eqkwargs):
     x = sparse.random((2, 3, 4), density=.5)


### PR DESCRIPTION
Giving negative axis indices for reductions raises errors, see #117. This PR fixes that.

Fixes #117 