### PR TITLE
Make COO canonical in the constructor.

### DIFF
--- a/benchmarks/benchmark_coo.py
+++ b/benchmarks/benchmark_coo.py
@@ -9,9 +9,6 @@ class ElemwiseSuite(object):
         self.x = sparse.random((100, 100, 100), density=0.01)
         self.y = sparse.random((100, 100, 100), density=0.01)
 
-        self.x.sum_duplicates()
-        self.y.sum_duplicates()
-
         self.x + self.y  # Numba compilation
 
     def time_add(self):
@@ -30,9 +27,6 @@ class ElemwiseBroadcastingSuite(object):
         self.x = sparse.random((100, 1, 100), density=0.01)
         self.y = sparse.random((100, 100), density=0.01)
 
-        self.x.sum_duplicates()
-        self.y.sum_duplicates()
-
     def time_add(self):
         self.x + self.y
 
@@ -44,8 +38,6 @@ class IndexingSuite(object):
     def setup(self):
         np.random.seed(0)
         self.x = sparse.random((100, 100, 100), density=0.01)
-        self.x.sum_duplicates()
-
         self.x[5]  # Numba compilation
 
     def time_index_scalar(self):

--- a/docs/generated/sparse.COO.rst
+++ b/docs/generated/sparse.COO.rst
@@ -69,5 +69,3 @@ COO
       COO.broadcast_to
       COO.enable_caching
       COO.linear_loc
-      COO.sort_indices
-      COO.sum_duplicates

--- a/docs/generated/sparse.COO.sort_indices.rst
+++ b/docs/generated/sparse.COO.sort_indices.rst
@@ -1,6 +1,0 @@
-COO\.sort\_indices
-==================
-
-.. currentmodule:: sparse
-
-.. automethod:: COO.sort_indices

--- a/docs/generated/sparse.COO.sum_duplicates.rst
+++ b/docs/generated/sparse.COO.sum_duplicates.rst
@@ -1,6 +1,0 @@
-COO\.sum\_duplicates
-====================
-
-.. currentmodule:: sparse
-
-.. automethod:: COO.sum_duplicates

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -37,7 +37,7 @@ but the sparse version takes up less space in memory
    >>> s.nbytes
    1102706
    >>> s
-   <COO: shape=(100, 100, 100), dtype=float64, nnz=100246, sorted=True, duplicates=False>
+   <COO: shape=(100, 100, 100), dtype=float64, nnz=100246>
 
 For more efficient ways to construct sparse arrays,
 see documentation on :doc:`Constructing Arrays <construct>`.
@@ -51,7 +51,7 @@ This includes arithmetic, :doc:`numpy.ufunc <reference/ufuncs>` operations, or f
 .. code-block:: python
 
    >>> np.sin(s) + s.T * 1
-   <COO: shape=(100, 100, 100), dtype=float64, nnz=189601, sorted=False, duplicates=False>
+   <COO: shape=(100, 100, 100), dtype=float64, nnz=189601>
 
 However, operations which convert the sparse array into a dense one will raise exceptions
 For example, the following raises a :obj:`ValueError`.

--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -194,10 +194,6 @@ def dot(a, b):
 def _dot(a, b):
     from .core import COO
 
-    if isinstance(a, COO):
-        a.sum_duplicates()
-    if isinstance(b, COO):
-        b.sum_duplicates()
     if isinstance(b, COO) and not isinstance(a, COO):
         return _dot(b.T, a.T).T
     aa = a.tocsr()
@@ -250,10 +246,8 @@ def concatenate(arrays, axis=0):
         dim += x.shape[axis]
         nnz += x.nnz
 
-    has_duplicates = any(x.has_duplicates for x in arrays)
-
-    return COO(coords, data, shape=shape, has_duplicates=has_duplicates,
-               sorted=(axis == 0) and all(a.sorted for a in arrays))
+    return COO(coords, data, shape=shape, has_duplicates=False,
+               sorted=(axis == 0))
 
 
 def stack(arrays, axis=0):
@@ -296,13 +290,12 @@ def stack(arrays, axis=0):
         dim += 1
         nnz += x.nnz
 
-    has_duplicates = any(x.has_duplicates for x in arrays)
     coords = [coords[i].astype(coords_dtype) for i in range(coords.shape[0])]
     coords.insert(axis, new)
     coords = np.stack(coords, axis=0)
 
-    return COO(coords, data, shape=shape, has_duplicates=has_duplicates,
-               sorted=(axis == 0) and all(a.sorted for a in arrays))
+    return COO(coords, data, shape=shape, has_duplicates=False,
+               sorted=(axis == 0))
 
 
 def triu(x, k=0):
@@ -336,7 +329,7 @@ def triu(x, k=0):
     coords = x.coords[:, mask]
     data = x.data[mask]
 
-    return COO(coords, data, x.shape, x.has_duplicates, x.sorted)
+    return COO(coords, data, shape=x.shape, has_duplicates=False, sorted=True)
 
 
 def tril(x, k=0):
@@ -370,7 +363,7 @@ def tril(x, k=0):
     coords = x.coords[:, mask]
     data = x.data[mask]
 
-    return COO(coords, data, x.shape, x.has_duplicates, x.sorted)
+    return COO(coords, data, shape=x.shape, has_duplicates=False, sorted=True)
 
 
 def nansum(x, axis=None, keepdims=False, dtype=None, out=None):
@@ -582,8 +575,8 @@ def _replace_nan(array, value):
     data[np.isnan(data)] = value
 
     return COO(array.coords, data, shape=array.shape,
-               has_duplicates=array.has_duplicates,
-               sorted=array.sorted)
+               has_duplicates=False,
+               sorted=True)
 
 
 def nanreduce(x, method, identity=None, axis=None, keepdims=False, **kwargs):

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -246,10 +246,10 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         assert not self.shape or len(data) == self.coords.shape[1]
 
         if not sorted:
-            self.sort_indices()
+            self._sort_indices()
 
         if has_duplicates:
-            self.sum_duplicates()
+            self._sum_duplicates()
 
     def _make_shallow_copy_of(self, other):
         self.coords = other.coords
@@ -1264,7 +1264,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
 
         return csc
 
-    def sort_indices(self):
+    def _sort_indices(self):
         """
         Sorts the :obj:`COO.coords` attribute. Also sorts the data in
         :obj:`COO.data` to match.
@@ -1274,7 +1274,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         >>> coords = np.array([[1, 2, 0]], dtype=np.uint8)
         >>> data = np.array([4, 1, 3], dtype=np.uint8)
         >>> s = COO(coords, data)
-        >>> s.sort_indices()
+        >>> s._sort_indices()
         >>> s.coords  # doctest: +NORMALIZE_WHITESPACE
         array([[0, 1, 2]], dtype=uint8)
         >>> s.data  # doctest: +NORMALIZE_WHITESPACE
@@ -1289,7 +1289,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         self.coords = self.coords[:, order]
         self.data = self.data[order]
 
-    def sum_duplicates(self):
+    def _sum_duplicates(self):
         """
         Sums data corresponding to duplicates in :obj:`COO.coords`.
 
@@ -1302,7 +1302,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         >>> coords = np.array([[0, 1, 1, 2]], dtype=np.uint8)
         >>> data = np.array([6, 5, 2, 2], dtype=np.uint8)
         >>> s = COO(coords, data)
-        >>> s.sum_duplicates()
+        >>> s._sum_duplicates()
         >>> s.coords  # doctest: +NORMALIZE_WHITESPACE
         array([[0, 1, 2]], dtype=uint8)
         >>> s.data  # doctest: +NORMALIZE_WHITESPACE

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -61,7 +61,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
     >>> x[2, 3] = 5
     >>> s = COO.from_numpy(x)
     >>> s
-    <COO: shape=(4, 4), dtype=uint8, nnz=5, sorted=True, duplicates=False>
+    <COO: shape=(4, 4), dtype=uint8, nnz=5>
     >>> s.data  # doctest: +NORMALIZE_WHITESPACE
     array([1, 1, 1, 5, 1], dtype=uint8)
     >>> s.coords  # doctest: +NORMALIZE_WHITESPACE
@@ -126,7 +126,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
     >>> data = [1, 2, 3, 4, 5]
     >>> s4 = COO(coords, data, shape=(3, 4, 5))
     >>> s4
-    <COO: shape=(3, 4, 5), dtype=int64, nnz=5, sorted=False, duplicates=True>
+    <COO: shape=(3, 4, 5), dtype=int64, nnz=5>
 
     Following scipy.sparse conventions you can also pass these as a tuple with
     rows and columns
@@ -147,7 +147,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
 
     >>> d = {(0, 0, 0): 1, (1, 2, 3): 2, (1, 1, 0): 3}
     >>> COO(d)
-    <COO: shape=(2, 3, 4), dtype=int64, nnz=3, sorted=False, duplicates=False>
+    <COO: shape=(2, 3, 4), dtype=int64, nnz=3>
     >>> L = [((0, 0), 1),
     ...      ((1, 1), 2),
     ...      ((0, 0), 3)]
@@ -164,7 +164,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
     <DOK: shape=(5, 5), dtype=int64, nnz=4>
     >>> s6 = COO(s5)
     >>> s6
-    <COO: shape=(5, 5), dtype=int64, nnz=4, sorted=False, duplicates=False>
+    <COO: shape=(5, 5), dtype=int64, nnz=4>
     >>> s6.todense()  # doctest: +NORMALIZE_WHITESPACE
     array([[0, 0, 0, 0, 0],
            [0, 4, 5, 0, 0],
@@ -244,14 +244,16 @@ class COO(SparseArray, NDArrayOperatorsMixin):
             dtype = np.uint8
         self.coords = self.coords.astype(dtype)
         assert not self.shape or len(data) == self.coords.shape[1]
-        self.has_duplicates = has_duplicates
-        self.sorted = sorted
+
+        if not sorted:
+            self.sort_indices()
+
+        if has_duplicates:
+            self.sum_duplicates()
 
     def _make_shallow_copy_of(self, other):
         self.coords = other.coords
         self.data = other.data
-        self.has_duplicates = other.has_duplicates
-        self.sorted = other.sorted
         super(COO, self).__init__(other.shape)
 
     def enable_caching(self):
@@ -298,7 +300,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         >>> x = np.eye(5)
         >>> s = COO.from_numpy(x)
         >>> s
-        <COO: shape=(5, 5), dtype=float64, nnz=5, sorted=True, duplicates=False>
+        <COO: shape=(5, 5), dtype=float64, nnz=5>
         """
         x = np.asanyarray(x)
         if x.shape:
@@ -335,7 +337,6 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         >>> np.array_equal(x, x2)
         True
         """
-        self.sum_duplicates()
         x = np.zeros(shape=self.shape, dtype=self.dtype)
 
         coords = tuple([self.coords[i, :] for i in range(self.ndim)])
@@ -489,9 +490,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
     __getitem__ = getitem
 
     def __str__(self):
-        return "<COO: shape=%s, dtype=%s, nnz=%d, sorted=%s, duplicates=%s>" % (
-            self.shape, self.dtype, self.nnz, self.sorted,
-            self.has_duplicates)
+        return "<COO: shape=%s, dtype=%s, nnz=%d>" % (self.shape, self.dtype, self.nnz)
 
     __repr__ = __str__
 
@@ -568,7 +567,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         By default, this reduces the array by only the first axis.
 
         >>> s.reduce(np.add)
-        <COO: shape=(5,), dtype=int64, nnz=5, sorted=True, duplicates=False>
+        <COO: shape=(5,), dtype=int64, nnz=5>
         """
         axis = normalize_axis(axis, self.ndim)
         zero_reduce_result = method.reduce([_zero_of_dtype(self.dtype)], **kwargs)
@@ -576,9 +575,6 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         if zero_reduce_result != _zero_of_dtype(np.dtype(zero_reduce_result)):
             raise ValueError("Performing this reduction operation would produce "
                              "a dense result: %s" % str(method))
-
-        # Needed for more esoteric reductions like product.
-        self.sum_duplicates()
 
         if axis is None:
             axis = tuple(range(self.ndim))
@@ -599,7 +595,6 @@ class COO(SparseArray, NDArrayOperatorsMixin):
             a = self.transpose(neg_axis + axis)
             a = a.reshape((np.prod([self.shape[d] for d in neg_axis]),
                            np.prod([self.shape[d] for d in axis])))
-            a.sort_indices()
 
             result, inv_idx, counts = _grouped_reduce(a.data, a.coords[0], method, **kwargs)
             missing_counts = counts != a.shape[1]
@@ -947,7 +942,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
 
         shape = tuple(self.shape[ax] for ax in axes)
         result = COO(self.coords[axes, :], self.data, shape,
-                     has_duplicates=self.has_duplicates,
+                     has_duplicates=False,
                      cache=self._cache is not None)
 
         if self._cache is not None:
@@ -1148,8 +1143,8 @@ class COO(SparseArray, NDArrayOperatorsMixin):
             strides *= d
 
         result = COO(coords, self.data, shape,
-                     has_duplicates=self.has_duplicates,
-                     sorted=self.sorted, cache=self._cache is not None)
+                     has_duplicates=False,
+                     sorted=True, cache=self._cache is not None)
 
         if self._cache is not None:
             self._cache['reshape'].append((shape, result))
@@ -1181,19 +1176,13 @@ class COO(SparseArray, NDArrayOperatorsMixin):
                                           (self.coords[0],
                                            self.coords[1])),
                                          shape=self.shape)
-        result.has_canonical_format = (not self.has_duplicates and self.sorted)
+        result.has_canonical_format = True
         return result
 
     def _tocsr(self):
         if self.ndim != 2:
             raise ValueError('This array must be two-dimensional for this conversion '
                              'to work.')
-
-        # Pass 1: sum duplicates
-        self.sum_duplicates()
-
-        # Pass 2: sort indices
-        self.sort_indices()
         row, col = self.coords
 
         # Pass 3: count nonzeros in each row
@@ -1291,19 +1280,14 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         >>> s.data  # doctest: +NORMALIZE_WHITESPACE
         array([3, 4, 1], dtype=uint8)
         """
-        if self.sorted:
-            return
-
         linear = self.linear_loc(signed=True)
 
         if (np.diff(linear) > 0).all():  # already sorted
-            self.sorted = True
             return
 
         order = np.argsort(linear)
         self.coords = self.coords[:, order]
         self.data = self.data[order]
-        self.sorted = True
 
     def sum_duplicates(self):
         """
@@ -1326,18 +1310,10 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         """
         # Inspired by scipy/sparse/coo.py::sum_duplicates
         # See https://github.com/scipy/scipy/blob/master/LICENSE.txt
-        if not self.has_duplicates and self.sorted:
-            return
-        if not self.coords.size:
-            return
-
-        self.sort_indices()
-
         linear = self.linear_loc()
         unique_mask = np.diff(linear) != 0
 
         if unique_mask.sum() == len(unique_mask):  # already unique
-            self.has_duplicates = False
             return
 
         unique_mask = np.append(True, unique_mask)
@@ -1348,7 +1324,6 @@ class COO(SparseArray, NDArrayOperatorsMixin):
 
         self.data = data
         self.coords = coords
-        self.has_duplicates = False
 
     def broadcast_to(self, shape):
         """

--- a/sparse/coo/indexing.py
+++ b/sparse/coo/indexing.py
@@ -29,8 +29,6 @@ def getitem(x, index):
     """
     from .core import COO
 
-    x.sum_duplicates()
-
     # If string, this is an index into an np.void
     # Custom dtype.
     if isinstance(index, str):

--- a/sparse/coo/indexing.py
+++ b/sparse/coo/indexing.py
@@ -41,8 +41,8 @@ def getitem(x, index):
 
         return COO(coords, data[idx].flatten(),
                    shape=x.shape + x.data.dtype[index].shape,
-                   has_duplicates=x.has_duplicates,
-                   sorted=x.sorted)
+                   has_duplicates=False,
+                   sorted=True)
 
     # Otherwise, convert into a tuple.
     if not isinstance(index, tuple):
@@ -106,8 +106,8 @@ def getitem(x, index):
     data = x.data[mask]
 
     return COO(coords, data, shape=shape,
-               has_duplicates=x.has_duplicates,
-               sorted=x.sorted)
+               has_duplicates=False,
+               sorted=True)
 
 
 def _mask(coords, indices, shape):

--- a/sparse/coo/umath.py
+++ b/sparse/coo/umath.py
@@ -150,10 +150,6 @@ def _elemwise_n_ary(func, *args, **kwargs):
 
     args = list(args)
 
-    for arg in args:
-        if isinstance(arg, COO):
-            arg.sum_duplicates()
-
     args_zeros = tuple(_zero_of_dtype(arg.dtype)[()] for arg in args)
 
     func_value = func(*args_zeros, **kwargs)
@@ -561,8 +557,8 @@ def _elemwise_unary(func, self, *args, **kwargs):
 
     return COO(self.coords[:, nonzero], data_func[nonzero],
                shape=self.shape,
-               has_duplicates=self.has_duplicates,
-               sorted=self.sorted)
+               has_duplicates=False,
+               sorted=True)
 
 
 def _get_matching_coords(coords, params, shape):
@@ -633,5 +629,5 @@ def broadcast_to(x, shape):
     params = _get_broadcast_parameters(x.shape, result_shape)
     coords, data = _get_expanded_coords_data(x.coords, x.data, params, result_shape)
 
-    return COO(coords, data, shape=result_shape, has_duplicates=x.has_duplicates,
-               sorted=x.sorted)
+    return COO(coords, data, shape=result_shape, has_duplicates=False,
+               sorted=True)

--- a/sparse/dok.py
+++ b/sparse/dok.py
@@ -60,7 +60,7 @@ class DOK(SparseArray):
     >>> from sparse import COO
     >>> s3 = COO(s2)
     >>> s3
-    <COO: shape=(5, 5), dtype=int64, nnz=4, sorted=False, duplicates=False>
+    <COO: shape=(5, 5), dtype=int64, nnz=4>
     >>> s2.todense()  # doctest: +NORMALIZE_WHITESPACE
     array([[0, 0, 0, 0, 0],
            [0, 4, 5, 0, 0],
@@ -70,7 +70,7 @@ class DOK(SparseArray):
 
     >>> s4 = COO.from_numpy(np.eye(4, dtype=np.uint8))
     >>> s4
-    <COO: shape=(4, 4), dtype=uint8, nnz=4, sorted=True, duplicates=False>
+    <COO: shape=(4, 4), dtype=uint8, nnz=4>
     >>> s5 = DOK.from_coo(s4)
     >>> s5
     <DOK: shape=(4, 4), dtype=uint8, nnz=4>
@@ -171,7 +171,7 @@ class DOK(SparseArray):
         <DOK: shape=(5, 5), dtype=float64, nnz=4>
         >>> s2 = s.to_coo()
         >>> s2
-        <COO: shape=(5, 5), dtype=float64, nnz=4, sorted=False, duplicates=False>
+        <COO: shape=(5, 5), dtype=float64, nnz=4>
         """
         from .coo import COO
         return COO(self)

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -76,7 +76,7 @@ def test_nan_reductions(reduction, axis, keepdims, fraction):
     x = s.todense()
     expected = getattr(np, reduction)(x, axis=axis, keepdims=keepdims)
     actual = getattr(sparse, reduction)(s, axis=axis, keepdims=keepdims)
-    assert_eq(expected, actual, equal_nan=True, check_nnz=False)
+    assert_eq(expected, actual, equal_nan=True)
 
 
 @pytest.mark.parametrize('reduction', [

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -7,7 +7,7 @@ import scipy.stats
 
 import sparse
 from sparse import COO
-from sparse.utils import assert_eq, is_lexsorted, random_value_array
+from sparse.utils import assert_eq, random_value_array
 
 
 @pytest.mark.parametrize('reduction,kwargs,eqkwargs', [
@@ -882,25 +882,6 @@ def test_slicing_errors(index):
         s[index]
 
 
-def test_canonical():
-    coords = np.array([[0, 0, 0],
-                       [0, 1, 0],
-                       [1, 0, 3],
-                       [0, 1, 0],
-                       [1, 0, 3]]).T
-    data = np.arange(5) + 1
-
-    old = COO(coords, data, shape=(2, 2, 5))
-    x = COO(coords, data, shape=(2, 2, 5))
-    x.sum_duplicates()
-
-    assert_eq(old, x)
-    # assert x.nnz == 5
-    # assert x.has_duplicates
-    assert x.nnz == 3
-    assert not x.has_duplicates
-
-
 def test_concatenate():
     xx = sparse.random((2, 3, 4), density=0.5)
     x = xx.todense()
@@ -1258,12 +1239,6 @@ def test_two_random_same_seed():
     s2 = sparse.random((2, 3, 4), 0.3, random_state=state)
 
     assert_eq(s1, s2)
-
-
-def test_random_sorted():
-    s = sparse.random((2, 3, 4), canonical_order=True)
-
-    assert is_lexsorted(s)
 
 
 @pytest.mark.parametrize('rvs, dtype', [

--- a/sparse/utils.py
+++ b/sparse/utils.py
@@ -15,6 +15,9 @@ def assert_eq(x, y, check_nnz=True, compare_dtype=True, **kwargs):
     if isinstance(y, COO):
         assert is_canonical(y)
 
+    if isinstance(x, COO) and isinstance(y, COO) and not check_nnz:
+        assert np.array_equal(x.coords, y.coords) and np.allclose(x.data, y.data, **kwargs)
+
     if hasattr(x, 'todense'):
         xx = x.todense()
         if check_nnz:
@@ -31,7 +34,7 @@ def assert_eq(x, y, check_nnz=True, compare_dtype=True, **kwargs):
 
 
 def is_canonical(x):
-    return not x.shape or (np.diff(x.linear_loc()) > 0).all()
+    return not x.shape or ((np.diff(x.linear_loc()) > 0).all() and (x.data != _zero_of_dtype(x.dtype)).all())
 
 
 def _zero_of_dtype(dtype):

--- a/sparse/utils.py
+++ b/sparse/utils.py
@@ -11,11 +11,9 @@ def assert_eq(x, y, check_nnz=True, compare_dtype=True, **kwargs):
         assert x.dtype == y.dtype
 
     if isinstance(x, COO):
-        if x.sorted:
-            assert is_lexsorted(x)
+        assert is_canonical(x)
     if isinstance(y, COO):
-        if y.sorted:
-            assert is_lexsorted(y)
+        assert is_canonical(y)
 
     if hasattr(x, 'todense'):
         xx = x.todense()
@@ -32,7 +30,7 @@ def assert_eq(x, y, check_nnz=True, compare_dtype=True, **kwargs):
     assert np.allclose(xx, yy, **kwargs)
 
 
-def is_lexsorted(x):
+def is_canonical(x):
     return not x.shape or (np.diff(x.linear_loc()) > 0).all()
 
 
@@ -56,7 +54,6 @@ def _zero_of_dtype(dtype):
 def random(
         shape,
         density=0.01,
-        canonical_order=False,
         random_state=None,
         data_rvs=None,
         format='coo'
@@ -69,9 +66,6 @@ def random(
         Shape of the array
     density: float, optional
         Density of the generated array.
-    canonical_order : bool, optional
-        Whether or not to put the output :obj:`COO` object into canonical
-        order. :code:`False` by default.
     random_state : Union[numpy.random.RandomState, int], optional
         Random number generator or random seed. If not given, the
         singleton numpy.random will be used. This random state will be used
@@ -145,9 +139,6 @@ def random(
     data = data_rvs(nnz)
 
     ar = COO(ind[None, :], data, shape=nnz).reshape(shape)
-
-    if canonical_order:
-        ar.sum_duplicates()
 
     if format == 'dok':
         ar = DOK(ar)


### PR DESCRIPTION
Based on recommendations in https://github.com/scipy/scipy/issues/8162#issuecomment-344469036 I believe that we should make `COO` always be canonical.

This has several advantages:

- Nobody really wants the non-canonical version.
- We don't have to keep track of when or if it's ever canonical.
- The `x.sum_duplicates()` calls just disappear.
- The string representation becomes simpler. The `sorted=?, duplicates=?` was just confusing to someone who didn't know how `COO` really worked.
- The object is now truly immutable.