### PR TITLE
add full function to simplify COO creation

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,7 +12,6 @@ flags:
   project:
     enabled: yes
     target: 95%
-    threshold: 1%
     if_no_uploads: error
     if_not_found: success
     if_ci_failed: error
@@ -21,7 +20,6 @@ flags:
     default:
       enabled: yes
       target: 95%
-      threshold: 1%
       if_no_uploads: error
       if_not_found: success
       if_ci_failed: error

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,9 @@ source=
 omit=
     sparse/_version.py
     sparse/tests/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    return NotImplemented
+    raise NotImplementedError

--- a/docs/generated/sparse.full.rst
+++ b/docs/generated/sparse.full.rst
@@ -1,0 +1,6 @@
+full
+====
+
+.. currentmodule:: sparse
+
+.. autofunction:: full

--- a/docs/generated/sparse.rst
+++ b/docs/generated/sparse.rst
@@ -29,6 +29,8 @@ API
 
     elemwise
 
+    full
+
     nanmax
 
     nanmin

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -20,13 +20,12 @@ results for both Numpy arrays, COO arrays, or a mix of the two:
 
    np.log(X.dot(beta.T) + 1)
 
-However some operations are not supported, like inplace operations,
-operations that implicitly cause dense structures,
-or numpy functions that are not yet implemented for sparse arrays
+However some operations are not supported, like operations that
+implicitly cause dense structures, or numpy functions that are not
+yet implemented for sparse arrays.
 
 .. code-block:: python
 
-   x += y     # inplace operations not supported
    x + 1      # operations that produce dense results not supported
    np.svd(x)  # sparse svd not implemented
 
@@ -34,7 +33,7 @@ or numpy functions that are not yet implemented for sparse arrays
 This page describes those valid operations, and their limitations.
 
 :obj:`elemwise`
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 This function allows you to apply any arbitrary broadcasting function to any number of arguments
 where the arguments can be :obj:`SparseArray` objects or :obj:`scipy.sparse.spmatrix` objects.
 For example, the following will add two arrays:
@@ -155,7 +154,9 @@ be a :obj:`scipy.sparse.spmatrix` The following operators are supported:
    * :obj:`operator.lshift` (:code:`x << y`)
    * :obj:`operator.rshift` (:code:`x >> y`)
 
-.. note:: In-place operators are not supported at this time.
+.. warning::
+   While in-place operations are supported for compatibility with Numpy,
+   they are not truly in-place, and will effectively calculate the result separately.
 
 .. _operations-elemwise:
 

--- a/sparse/coo/__init__.py
+++ b/sparse/coo/__init__.py
@@ -1,4 +1,4 @@
 from .core import COO
 from .umath import elemwise
 from .common import tensordot, dot, concatenate, stack, triu, tril, where, \
-    nansum, nanprod, nanmin, nanmax, nanreduce
+    nansum, nanprod, nanmin, nanmax, nanreduce, full

--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -616,3 +616,32 @@ def nanreduce(x, method, identity=None, axis=None, keepdims=False, **kwargs):
     """
     arr = _replace_nan(x, method.identity if identity is None else identity)
     return arr.reduce(method, axis, keepdims, **kwargs)
+
+
+def full(coords, fill_value, dtype=None, **kwargs):
+    """
+    Return a new COO of with a given sparsity pattern, filled with fill_value.
+
+    Parameters
+    ----------
+    coords : numpy.ndarray (COO.ndim, COO.nnz)
+        Index locations of nonzero values.
+    fill_value: scalar
+        Value of array at nonzero indices.
+    dtype : data-type (optional)
+        The data-type for the array. If None, defaults to
+        `np.array(fill_value).dtype`.
+
+    Returns
+    -------
+    COO
+        Newly constructed sparse array.
+
+    See Also
+    --------
+    numpy.full : Analogous Numpy function.
+    """
+    from .core import COO
+
+    d = np.full(coords.shape[1], fill_value, dtype=dtype)
+    return COO(coords, data=d, **kwargs)

--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -631,6 +631,8 @@ def full(coords, fill_value, dtype=None, **kwargs):
     dtype : data-type (optional)
         The data-type for the array. If None, defaults to
         `np.array(fill_value).dtype`.
+    kwargs : dict (optional)
+        Additional arguments to pass to ``COO`` constructor.
 
     Returns
     -------
@@ -643,5 +645,5 @@ def full(coords, fill_value, dtype=None, **kwargs):
     """
     from .core import COO
 
-    d = np.full(coords.shape[1], fill_value, dtype=dtype)
+    d = np.full(np.asarray(coords).shape[1], fill_value, dtype=dtype)
     return COO(coords, data=d, **kwargs)

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -223,8 +223,9 @@ class COO(SparseArray, NDArrayOperatorsMixin):
                 data = coords[0]
                 coords = np.stack(coords[1], axis=0)
 
-        self.data = np.asarray(data)
         self.coords = np.asarray(coords)
+        self.data = np.broadcast_to(data, self.coords.shape[-1])
+
         if self.coords.ndim == 1:
             self.coords = self.coords[None, :]
 
@@ -243,7 +244,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         else:
             dtype = np.uint8
         self.coords = self.coords.astype(dtype)
-        assert not self.shape or len(data) == self.coords.shape[1]
+        assert not self.shape or len(self.data) == self.coords.shape[1]
 
         if not sorted:
             self._sort_indices()

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -677,8 +677,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         >>> s.sum()
         25
         """
-        assert out is None
-        return self.reduce(np.add, axis=axis, keepdims=keepdims, dtype=dtype)
+        return np.add.reduce(self, out=out, axis=axis, keepdims=keepdims, dtype=dtype)
 
     def max(self, axis=None, keepdims=False, out=None):
         """
@@ -739,8 +738,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         >>> s.max()
         8
         """
-        assert out is None
-        return self.reduce(np.maximum, axis=axis, keepdims=keepdims)
+        return np.maximum.reduce(self, out=out, axis=axis, keepdims=keepdims)
 
     def min(self, axis=None, keepdims=False, out=None):
         """
@@ -801,8 +799,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         >>> s.min()
         0
         """
-        assert out is None
-        return self.reduce(np.minimum, axis=axis, keepdims=keepdims)
+        return np.minimum.reduce(self, out=out, axis=axis, keepdims=keepdims)
 
     def prod(self, axis=None, keepdims=False, dtype=None, out=None):
         """
@@ -868,8 +865,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         >>> s.prod()
         0
         """
-        assert out is None
-        return self.reduce(np.multiply, axis=axis, keepdims=keepdims, dtype=dtype)
+        return np.multiply.reduce(self, out=out, axis=axis, keepdims=keepdims, dtype=dtype)
 
     def transpose(self, axes=None):
         """
@@ -1040,15 +1036,26 @@ class COO(SparseArray, NDArrayOperatorsMixin):
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         out = kwargs.pop('out', None)
-        if out is not None:
+        if out is not None and not all(isinstance(x, COO) for x in out):
             return NotImplemented
 
         if method == '__call__':
-            return elemwise(ufunc, *inputs, **kwargs)
+            result = elemwise(ufunc, *inputs, **kwargs)
         elif method == 'reduce':
-            return COO._reduce(ufunc, *inputs, **kwargs)
+            result = COO._reduce(ufunc, *inputs, **kwargs)
         else:
             return NotImplemented
+
+        if out is not None:
+            (out,) = out
+            if out.shape != result.shape:
+                raise ValueError('non-broadcastable output operand with shape %s'
+                                 'doesn\'t match the broadcast shape %s' % (out.shape, result.shape))
+
+            out._make_shallow_copy_of(result)
+            return out
+
+        return result
 
     def __array__(self, dtype=None, **kwargs):
         x = self.todense()
@@ -1367,10 +1374,11 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         The :code:`out` parameter is provided just for compatibility with Numpy and isn't
         actually supported.
         """
-        assert out is None
-        return elemwise(np.round, self, decimals=decimals)
+        if out is not None and not isinstance(out, tuple):
+            out = (out,)
+        return self.__array_ufunc__(np.round, '__call__', self, decimals=decimals, out=out)
 
-    def astype(self, dtype, out=None):
+    def astype(self, dtype):
         """
         Copy of the array, cast to a specified type.
 
@@ -1386,8 +1394,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         The :code:`out` parameter is provided just for compatibility with Numpy and isn't
         actually supported.
         """
-        assert out is None
-        return elemwise(np.ndarray.astype, self, dtype=dtype)
+        return self.__array_ufunc__(np.ndarray.astype, '__call__', self, dtype=dtype)
 
     def maybe_densify(self, max_size=1000, min_density=0.25):
         """

--- a/sparse/coo/umath.py
+++ b/sparse/coo/umath.py
@@ -64,8 +64,7 @@ def elemwise(func, *args, **kwargs):
         elif isinstance(arg, SparseArray) and not isinstance(arg, COO):
             args[i] = COO(arg)
         elif not isinstance(arg, COO):
-            raise ValueError("Performing this operation would produce "
-                             "a dense result: %s" % str(func))
+            return NotImplemented
 
     # Filter out scalars as they are 'baked' into the function.
     func = PositinalArgumentPartial(func, pos, posargs)

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1402,8 +1402,15 @@ def test_full():
 
     a = sparse.full(coords, 1)
     e = np.diag(np.ones(5, dtype=int))
-    assert_eq(e, a, compare_dtype=True)
+    assert_eq(e, a)
+    assert_eq(e, COO(coords, 1))
 
     a = sparse.full(coords, 1.0)
-    e = np.diag(np.ones(5))
-    assert_eq(e, a, compare_dtype=True)
+    e = np.eye(5)
+    assert_eq(e, a)
+    assert_eq(e, COO(coords, 1.0))
+
+    a = sparse.full(coords.tolist(), -1.0)
+    e = -np.eye(5)
+    assert_eq(e, a)
+    assert_eq(e, COO(coords, -1.0))

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1395,3 +1395,15 @@ def test_argwhere():
     x = s.todense()
 
     assert_eq(np.argwhere(s), np.argwhere(x), compare_dtype=False)
+
+
+def test_full():
+    coords = np.tile(np.arange(5), (2, 1))
+
+    a = sparse.full(coords, 1)
+    e = np.diag(np.ones(5, dtype=int))
+    assert_eq(e, a, compare_dtype=True)
+
+    a = sparse.full(coords, 1.0)
+    e = np.diag(np.ones(5))
+    assert_eq(e, a, compare_dtype=True)


### PR DESCRIPTION
This package may end up being very important to me, so I wanted to dip my toes in and try adding a simple extension in case I want to add something more substantial later.

The basic idea is to make array creation easier when all the data values are the same (I think this is incredibly common, e.g. if you are representing sparse graph structure)

```python
sparse.full(np.array([[0,1,2],[0,1,2]]), 1).todense()

array([[1, 0, 0],
       [0, 1, 0],
       [0, 0, 1]])
```

A few things I wasn't sure on...
* how to document `**kwargs`
* Should I be accepting non-array objects for `coords`? In particular should I add something to the effect of `coords = np.asarray(coords)` at the top of my function

Hope that this is welcome and within scope. Thanks!