### PR TITLE
A range of fixes relating to small coords dtypes

### DIFF
--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -44,16 +44,12 @@ def asCOO(x, name='asCOO', check=True):
     return x
 
 
-def linear_loc(coords, shape, signed=False):
-    n = reduce(operator.mul, shape, 1)
-    if signed:
-        n = -n
-    dtype = np.min_scalar_type(n)
-    out = np.zeros(coords.shape[1], dtype=dtype)
-    tmp = np.zeros(coords.shape[1], dtype=dtype)
+def linear_loc(coords, shape):
+    out = np.zeros(coords.shape[1], dtype=np.intp)
+    tmp = np.zeros(coords.shape[1], dtype=np.intp)
     strides = 1
     for i, d in enumerate(shape[::-1]):
-        np.multiply(coords[-(i + 1), :], strides, out=tmp, dtype=dtype)
+        np.multiply(coords[-(i + 1), :], strides, out=tmp)
         np.add(tmp, out, out=out)
         strides *= d
     return out
@@ -235,9 +231,8 @@ def concatenate(arrays, axis=0):
     shape = list(arrays[0].shape)
     shape[axis] = dim
 
-    coords_dtype = np.min_scalar_type(max(shape) - 1) if len(shape) != 0 else np.uint8
     data = np.concatenate([x.data for x in arrays])
-    coords = np.concatenate([x.coords for x in arrays], axis=1).astype(coords_dtype)
+    coords = np.concatenate([x.coords for x in arrays], axis=1)
 
     dim = 0
     for x in arrays:
@@ -280,17 +275,15 @@ def stack(arrays, axis=0):
     shape = list(arrays[0].shape)
     shape.insert(axis, len(arrays))
 
-    coords_dtype = np.min_scalar_type(max(shape) - 1) if len(shape) != 0 else np.uint8
-
     nnz = 0
     dim = 0
-    new = np.empty(shape=(coords.shape[1],), dtype=coords_dtype)
+    new = np.empty(shape=(coords.shape[1],), dtype=np.intp)
     for x in arrays:
         new[nnz:x.nnz + nnz] = dim
         dim += 1
         nnz += x.nnz
 
-    coords = [coords[i].astype(coords_dtype) for i in range(coords.shape[0])]
+    coords = [coords[i] for i in range(coords.shape[0])]
     coords.insert(axis, new)
     coords = np.stack(coords, axis=0)
 

--- a/sparse/coo/indexing.py
+++ b/sparse/coo/indexing.py
@@ -68,6 +68,9 @@ def getitem(x, index):
     coords = []
     shape = []
     i = 0
+
+    sorted = True
+
     for ind in index:
         # Nothing is added to shape or coords if the index is an integer.
         if isinstance(ind, Integral):
@@ -76,14 +79,16 @@ def getitem(x, index):
         # Add to the shape and transform the coords in the case of a slice.
         elif isinstance(ind, slice):
             shape.append(len(range(ind.start, ind.stop, ind.step)))
-            dt = np.min_scalar_type(min(-(dim - 1) if dim != 0 else -1 for dim in shape))
-            coords.append((x.coords[i, mask].astype(dt) - ind.start) // ind.step)
+            coords.append((x.coords[i, mask] - ind.start) // ind.step)
             i += 1
+
+            if ind.step < 0:
+                sorted = False
         elif isinstance(ind, Iterable):
             raise NotImplementedError('Advanced indexing is not yet supported.')
         # Add a dimension for None.
         elif ind is None:
-            coords.append(np.zeros(n))
+            coords.append(np.zeros(n, dtype=np.intp))
             shape.append(1)
 
     # Join all the transformed coords.
@@ -105,7 +110,7 @@ def getitem(x, index):
 
     return COO(coords, data, shape=shape,
                has_duplicates=False,
-               sorted=True)
+               sorted=sorted)
 
 
 def _mask(coords, indices, shape):

--- a/sparse/coo/umath.py
+++ b/sparse/coo/umath.py
@@ -170,7 +170,7 @@ def _elemwise_n_ary(func, *args, **kwargs):
     # Concatenate matches and mismatches
     data = np.concatenate(data_list) if len(data_list) else np.empty((0,), dtype=func_value.dtype)
     coords = np.concatenate(coords_list, axis=1) if len(coords_list) else \
-        np.empty((0, len(result_shape)), dtype=np.min_scalar_type(max(result_shape) - 1))
+        np.empty((0, len(result_shape)), dtype=np.intp)
 
     return COO(coords, data, shape=result_shape, has_duplicates=False)
 
@@ -487,13 +487,12 @@ def _get_expanded_coords_data(coords, data, params, broadcast_shape):
         if not p:
             expand_shapes.append(l)
 
-    all_idx = _cartesian_product(*(np.arange(d, dtype=np.min_scalar_type(d - 1)) for d in expand_shapes))
-    dt = np.result_type(*(np.min_scalar_type(l - 1) for l in broadcast_shape))
+    all_idx = _cartesian_product(*(np.arange(d, dtype=np.intp) for d in expand_shapes))
 
     false_dim = 0
     dim = 0
 
-    expanded_coords = np.empty((len(broadcast_shape), all_idx.shape[1]), dtype=dt)
+    expanded_coords = np.empty((len(broadcast_shape), all_idx.shape[1]), dtype=np.intp)
     expanded_data = data[all_idx[first_dim]]
 
     for d, p, l in zip(range(len(broadcast_shape)), params, broadcast_shape):
@@ -569,9 +568,7 @@ def _get_matching_coords(coords, params, shape):
             if p is not None:
                 dims[i] += 1
 
-    dtype = np.min_scalar_type(max(shape) - 1)
-
-    return np.asarray(matching_coords, dtype=dtype)
+    return np.asarray(matching_coords, dtype=np.intp)
 
 
 def broadcast_to(x, shape):
@@ -608,4 +605,4 @@ def broadcast_to(x, shape):
     coords, data = _get_expanded_coords_data(x.coords, x.data, params, result_shape)
 
     return COO(coords, data, shape=result_shape, has_duplicates=False,
-               sorted=True)
+               sorted=False)

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -359,9 +359,11 @@ def test_binary_broadcasting(func, shape1, shape2):
     assert np.count_nonzero(expected) == actual.nnz
 
 
-@pytest.mark.parametrize('shape1,shape2', [((3, 4), (2, 3, 4)),
-                                           ((3, 1, 4), (3, 2, 4)),
-                                           ((3, 4, 1), (3, 4, 2))])
+@pytest.mark.parametrize('shape1,shape2', [
+    ((3, 4), (2, 3, 4)),
+    ((3, 1, 4), (3, 2, 4)),
+    ((3, 4, 1), (3, 4, 2))
+])
 def test_broadcast_to(shape1, shape2):
     a = sparse.random(shape1, density=0.5)
     x = a.todense()
@@ -1027,14 +1029,6 @@ def test_large_concat_stack():
 
     assert_eq(np.concatenate((x, x)),
               sparse.concatenate((xs, xs)))
-
-
-def test_coord_dtype():
-    s = sparse.random((2, 3, 4), density=0.5)
-    assert s.coords.dtype == np.uint8
-
-    s = COO.from_numpy(np.zeros(1000))
-    assert s.coords.dtype == np.uint16
 
 
 def test_addition():

--- a/sparse/utils.py
+++ b/sparse/utils.py
@@ -21,6 +21,7 @@ def assert_eq(x, y, check_nnz=True, compare_dtype=True, **kwargs):
 
     if isinstance(x, COO) and isinstance(y, COO) and check_nnz:
         assert np.array_equal(x.coords, y.coords) and checking_method(x.data, y.data, **kwargs)
+        return
 
     if hasattr(x, 'todense'):
         xx = x.todense()


### PR DESCRIPTION
There was a range of bugs relating to small `coords` dtypes (used to save memory) often causing overflows and other bugs, also in interaction with `dask.array`

I removed all `np.min_scalar_type` instances as well as custom small `coords` instances.

This led to a few other bugs, which were also fixed. First seen in https://github.com/scipy-conference/scipy_proceedings/pull/388#discussion_r194598625

Example from that here: https://gist.github.com/hameerabbasi/0230eb7b6359416d1db4167f802ada83

