### PR TITLE
Implement roll (circular shift of elements)

### DIFF
--- a/docs/generated/sparse.roll.rst
+++ b/docs/generated/sparse.roll.rst
@@ -1,0 +1,6 @@
+roll
+====
+
+.. currentmodule:: sparse
+
+.. autofunction:: roll

--- a/docs/generated/sparse.rst
+++ b/docs/generated/sparse.rst
@@ -45,6 +45,8 @@ API
 
     random
 
+    roll
+
     save_npz
 
     stack

--- a/sparse/coo/__init__.py
+++ b/sparse/coo/__init__.py
@@ -1,4 +1,4 @@
 from .core import COO, as_coo
 from .umath import elemwise
 from .common import tensordot, dot, concatenate, stack, triu, tril, where, \
-    nansum, nanprod, nanmin, nanmax, nanreduce
+    nansum, nanprod, nanmin, nanmax, nanreduce, roll


### PR DESCRIPTION
This is my attempt to implement the equivalent of [`numpy.roll`](https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.roll.html) which I think would be really useful to have in this package.

I think this is nearly done, but it could be improved. In particular, the function is supposed to produce a copy of the array but I wasn't sure the preferred way of doing that so I called the `COO` constructor directly. Also, my function assumes a COO array as input, which is maybe not so flexible as other sparse array types are developed?

Thanks again for providing this awesome package. Looking forward to your comments!