### PR TITLE
MAINT: better error messages for initialization

### DIFF
--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -217,8 +217,19 @@ class COO(SparseArray, NDArrayOperatorsMixin):
 
         super(COO, self).__init__(shape, fill_value=fill_value)
         self.coords = self.coords.astype(np.intp)
-        assert not self.shape or (len(self.data) == self.coords.shape[1] and
-                                  len(self.shape) == self.coords.shape[0])
+
+        if self.shape:
+            if len(self.data) != self.coords.shape[1]:
+                msg = ('The data length does not match the coordinates '
+                       'given.\nlen(data) = {}, but {} coords specified.')
+                raise ValueError(msg.format(len(data), self.coords.shape[1]))
+            if len(self.shape) != self.coords.shape[0]:
+                msg = ("Shape specified by `shape` doesn't match the "
+                       "shape of `coords`; len(shape)={} != coords.shape[0]={}"
+                       "(and coords.shape={})")
+                raise ValueError(msg.format(len(shape),
+                                            self.coords.shape[0],
+                                            self.coords.shape))
 
         if not sorted:
             self._sort_indices()

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1640,3 +1640,20 @@ class TestFailFillValue(object):
 
         with pytest.raises(ValueError):
             sparse.concatenate([xs, ys])
+
+
+@pytest.mark.parametrize("ndim", [2, 3, 4, 5])
+def test_initialization(ndim):
+    shape = [10, ] * ndim
+    shape[1] *= 2
+    shape = tuple(shape)
+
+    coords = np.random.randint(10, size=ndim * 20).reshape(ndim, 20)
+    data = np.random.rand(20)
+    COO(coords, data=data, shape=shape)
+
+    with pytest.raises(ValueError, match="data length"):
+        COO(coords, data=data[:5], shape=shape)
+    with pytest.raises(ValueError, match="shape of `coords`"):
+        coords = np.random.randint(10, size=20).reshape(1, 20)
+        COO(coords, data=data, shape=shape)


### PR DESCRIPTION
During initialization, I kept on running into an assert. This PR resolves that and provides a better error message.

Why is `coords` in the shape it is? I would expect `coords.T` to be passed to `__init__`. That is, instead of `coords.shape == (ndim, num_points)`, I would expect `coords.shape == (num_points, ndim)`.