### PR TITLE
tweaked reduce method to return COO with correct fill_value

### DIFF
--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -691,7 +691,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
             result = result[mask]
 
             a = COO(coords, result, shape=(a.shape[0],),
-                    has_duplicates=False, sorted=True)
+                    has_duplicates=False, sorted=True, fill_value=self.fill_value)
 
             a = a.reshape(tuple(self.shape[d] for d in neg_axis))
             result = a

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1584,6 +1584,17 @@ def test_invalid_iterable_error():
         COO.from_iter(x)
 
 
+def test_prod_along_axis():
+    s1 = sparse.random((10, 10), density=0.1)
+    s2 = 1 - s1
+
+    x1 = s1.todense()
+    x2 = s2.todense()
+
+    assert_eq(s1.prod(axis=0), x1.prod(axis=0))
+    assert_eq(s2.prod(axis=0), x2.prod(axis=0))
+
+
 class TestRoll(object):
 
     # test on 1d array #


### PR DESCRIPTION
This is the error that this pull request fixes
```
>>> A = sparse.random((10, 10), density=0.1)
>>> A
<COO: shape=(10, 10), dtype=float64, nnz=10, fill_value=0.0>
>>> B = 1-A
>>> B
<COO: shape=(10, 10), dtype=float64, nnz=10, fill_value=1.0>
>>> B.prod(axis=0)
<COO: shape=(10,), dtype=float64, nnz=8, fill_value=0.0>
```
The `fill_value` should remain `fill_value=1.0` for the object to remain correct.