### PR TITLE
Add eye, zeros, zeros_like, ones, ones_like

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* :feature:`183` Added :code:`sparse.eye`, :code:`sparse.zeros`,
+  :code:`sparse.zeros_like`, :code:`sparse.ones`, and :code:`sparse.ones_like`.
 * :release:`0.4.1 <2018-09-12>`
 * :feature:`124` (via :issue:`182`) Allow mixed :code:`ndarray`-:obj:`COO` operations if the result is sparse.
 * :feature:`179` (via :issue:`180`) Allow specifying a fill-value when converting from NumPy arrays.

--- a/docs/generated/sparse.eye.rst
+++ b/docs/generated/sparse.eye.rst
@@ -1,0 +1,6 @@
+eye
+===
+
+.. currentmodule:: sparse
+
+.. autofunction:: eye

--- a/docs/generated/sparse.ones.rst
+++ b/docs/generated/sparse.ones.rst
@@ -1,0 +1,6 @@
+ones
+====
+
+.. currentmodule:: sparse
+
+.. autofunction:: ones

--- a/docs/generated/sparse.ones_like.rst
+++ b/docs/generated/sparse.ones_like.rst
@@ -1,0 +1,6 @@
+ones_like
+=========
+
+.. currentmodule:: sparse
+
+.. autofunction:: ones_like

--- a/docs/generated/sparse.rst
+++ b/docs/generated/sparse.rst
@@ -45,6 +45,10 @@ API
 
     nansum
 
+    ones
+
+    ones_like
+
     random
 
     roll

--- a/docs/generated/sparse.rst
+++ b/docs/generated/sparse.rst
@@ -27,6 +27,8 @@ API
 
     concatenate
 
+    eye
+
     dot
 
     elemwise
@@ -58,3 +60,7 @@ API
     triu
 
     where
+
+    zeros
+
+    zeros_like

--- a/docs/generated/sparse.zeros.rst
+++ b/docs/generated/sparse.zeros.rst
@@ -1,0 +1,6 @@
+zeros
+=====
+
+.. currentmodule:: sparse
+
+.. autofunction:: zeros

--- a/docs/generated/sparse.zeros_like.rst
+++ b/docs/generated/sparse.zeros_like.rst
@@ -1,0 +1,6 @@
+zeros_like
+==========
+
+.. currentmodule:: sparse
+
+.. autofunction:: zeros_like

--- a/sparse/coo/__init__.py
+++ b/sparse/coo/__init__.py
@@ -2,4 +2,4 @@ from .core import COO, as_coo
 from .umath import elemwise
 from .common import (tensordot, dot, concatenate, stack, triu, tril, where,
                      nansum, nanprod, nanmin, nanmax, nanreduce, roll, eye,
-                     zeros, zeros_like)
+                     zeros, zeros_like, ones, ones_like)

--- a/sparse/coo/__init__.py
+++ b/sparse/coo/__init__.py
@@ -2,4 +2,4 @@ from .core import COO, as_coo
 from .umath import elemwise
 from .common import (tensordot, dot, concatenate, stack, triu, tril, where,
                      nansum, nanprod, nanmin, nanmax, nanreduce, roll, eye,
-                     zeros)
+                     zeros, zeros_like)

--- a/sparse/coo/__init__.py
+++ b/sparse/coo/__init__.py
@@ -1,4 +1,5 @@
 from .core import COO, as_coo
 from .umath import elemwise
 from .common import (tensordot, dot, concatenate, stack, triu, tril, where,
-                     nansum, nanprod, nanmin, nanmax, nanreduce, roll, eye)
+                     nansum, nanprod, nanmin, nanmax, nanreduce, roll, eye,
+                     zeros)

--- a/sparse/coo/__init__.py
+++ b/sparse/coo/__init__.py
@@ -1,4 +1,4 @@
 from .core import COO, as_coo
 from .umath import elemwise
-from .common import tensordot, dot, concatenate, stack, triu, tril, where, \
-    nansum, nanprod, nanmin, nanmax, nanreduce, roll
+from .common import (tensordot, dot, concatenate, stack, triu, tril, where,
+                     nansum, nanprod, nanmin, nanmax, nanreduce, roll, eye)

--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -762,9 +762,10 @@ def eye(N, M=None, k=0, dtype=float):
         n_coords = m_coords = np.arange(data_length, dtype=np.intp)
 
     coords = np.stack([n_coords, m_coords])
-    data = np.ones(data_length, dtype=dtype)
+    data = np.array(1, dtype=dtype)
 
-    return COO(coords, data=data, shape=(N, M), has_duplicates=False)
+    return COO(coords, data=data, shape=(N, M), has_duplicates=False,
+               sorted=True)
 
 
 def zeros(shape, dtype=float):
@@ -798,7 +799,8 @@ def zeros(shape, dtype=float):
         shape = (shape,)
     data = np.empty(0, dtype=dtype)
     coords = np.empty((len(shape), 0), dtype=np.intp)
-    return COO(coords, data=data, shape=shape, has_duplicates=False)
+    return COO(coords, data=data, shape=shape, has_duplicates=False,
+               sorted=True)
 
 
 def zeros_like(a, dtype=None):
@@ -824,3 +826,63 @@ def zeros_like(a, dtype=None):
            [0, 0, 0]])
     """
     return zeros(a.shape, dtype=(a.dtype if dtype is None else dtype))
+
+
+def ones(shape, dtype=float):
+    """Return a COO array of given shape and type, filled with ones.
+
+    Parameters
+    ----------
+    shape : int or tuple of ints
+        Shape of the new array, e.g., ``(2, 3)`` or ``2``.
+    dtype : data-type, optional
+        The desired data-type for the array, e.g., `numpy.int8`.  Default is
+        `numpy.float64`.
+
+    Returns
+    -------
+    out : COO
+        Array of ones with the given shape and dtype.
+
+    Examples
+    --------
+    >>> ones(5).todense()  # doctest: +SKIP
+    array([1., 1., 1., 1., 1.])
+
+    >>> ones((2, 2), dtype=int).todense()  # doctest: +NORMALIZE_WHITESPACE
+    array([[1, 1],
+           [1, 1]])
+    """
+    from .core import COO
+
+    if not isinstance(shape, tuple):
+        shape = (shape,)
+    data = np.empty(0, dtype=dtype)
+    coords = np.empty((len(shape), 0), dtype=np.intp)
+    return COO(coords, data=data, shape=shape, fill_value=1,
+               has_duplicates=False, sorted=True)
+
+
+def ones_like(a, dtype=None):
+    """Return a COO array of ones with the same shape and type as ``a``.
+
+    Parameters
+    ----------
+    a : array_like
+        The shape and data-type of the result will match those of `a`.
+    dtype : data-type, optional
+        Overrides the data type of the result.
+
+    Returns
+    -------
+    out : COO
+        Array of ones with the same shape and type as `a`.
+
+    Examples
+    --------
+    >>> x = np.ones((2, 3), dtype='i8')
+    >>> ones_like(x).todense()  # doctest: +NORMALIZE_WHITESPACE
+    array([[1, 1, 1],
+           [1, 1, 1]])
+    """
+    return ones(a.shape, dtype=(a.dtype if dtype is None else dtype))

--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -734,7 +734,7 @@ def eye(N, M=None, k=0, dtype=float):
     >>> eye(2, dtype=int).todense()  # doctest: +NORMALIZE_WHITESPACE
     array([[1, 0],
            [0, 1]])
-    >>> eye(3, k=1).todense()  # doctest: +NORMALIZE_WHITESPACE
+    >>> eye(3, k=1).todense()  # doctest: +SKIP
     array([[0., 1., 0.],
            [0., 0., 1.],
            [0., 0., 0.]])
@@ -785,10 +785,10 @@ def zeros(shape, dtype=float):
 
     Examples
     --------
-    >>> zeros(5).todense()
+    >>> zeros(5).todense()  # doctest: +SKIP
     array([0., 0., 0., 0., 0.])
 
-    >>> zeros((2, 2), dtype=int).todense()
+    >>> zeros((2, 2), dtype=int).todense()  # doctest: +NORMALIZE_WHITESPACE
     array([[0, 0],
            [0, 0]])
     """

--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -799,3 +799,28 @@ def zeros(shape, dtype=float):
     data = np.empty(0, dtype=dtype)
     coords = np.empty((len(shape), 0), dtype=np.intp)
     return COO(coords, data=data, shape=shape, has_duplicates=False)
+
+
+def zeros_like(a, dtype=None):
+    """Return a COO array of zeros with the same shape and type as ``a``.
+
+    Parameters
+    ----------
+    a : array_like
+        The shape and data-type of the result will match those of `a`.
+    dtype : data-type, optional
+        Overrides the data type of the result.
+
+    Returns
+    -------
+    out : COO
+        Array of zeros with the same shape and type as `a`.
+
+    Examples
+    --------
+    >>> x = np.ones((2, 3), dtype='i8')
+    >>> zeros_like(x).todense()  # doctest: +NORMALIZE_WHITESPACE
+    array([[0, 0, 0],
+           [0, 0, 0]])
+    """
+    return zeros(a.shape, dtype=(a.dtype if dtype is None else dtype))

--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -752,16 +752,50 @@ def eye(N, M=None, k=0, dtype=float):
 
     if k > 0:
         data_length = max(min(data_length, M - k), 0)
-        n_coords = np.arange(data_length)
+        n_coords = np.arange(data_length, dtype=np.intp)
         m_coords = n_coords + k
     elif k < 0:
         data_length = max(min(data_length, N + k), 0)
-        m_coords = np.arange(data_length)
+        m_coords = np.arange(data_length, dtype=np.intp)
         n_coords = m_coords - k
     else:
-        n_coords = m_coords = np.arange(data_length)
+        n_coords = m_coords = np.arange(data_length, dtype=np.intp)
 
     coords = np.stack([n_coords, m_coords])
     data = np.ones(data_length, dtype=dtype)
 
     return COO(coords, data=data, shape=(N, M), has_duplicates=False)
+
+
+def zeros(shape, dtype=float):
+    """Return a COO array of given shape and type, filled with zeros.
+
+    Parameters
+    ----------
+    shape : int or tuple of ints
+        Shape of the new array, e.g., ``(2, 3)`` or ``2``.
+    dtype : data-type, optional
+        The desired data-type for the array, e.g., `numpy.int8`.  Default is
+        `numpy.float64`.
+
+    Returns
+    -------
+    out : COO
+        Array of zeros with the given shape and dtype.
+
+    Examples
+    --------
+    >>> zeros(5).todense()
+    array([0., 0., 0., 0., 0.])
+
+    >>> zeros((2, 2), dtype=int).todense()
+    array([[0, 0],
+           [0, 0]])
+    """
+    from .core import COO
+
+    if not isinstance(shape, tuple):
+        shape = (shape,)
+    data = np.empty(0, dtype=dtype)
+    coords = np.empty((len(shape), 0), dtype=np.intp)
+    return COO(coords, data=data, shape=shape, has_duplicates=False)

--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -705,3 +705,63 @@ def roll(a, shift, axis=None):
             coords[ax] %= a.shape[ax]
 
         return COO(coords, data=data, shape=a.shape, has_duplicates=False, fill_value=a.fill_value)
+
+
+def eye(N, M=None, k=0, dtype=float):
+    """Return a 2-D COO array with ones on the diagonal and zeros elsewhere.
+
+    Parameters
+    ----------
+    N : int
+        Number of rows in the output.
+    M : int, optional
+        Number of columns in the output. If None, defaults to `N`.
+    k : int, optional
+        Index of the diagonal: 0 (the default) refers to the main diagonal,
+        a positive value refers to an upper diagonal, and a negative value
+        to a lower diagonal.
+    dtype : data-type, optional
+        Data-type of the returned array.
+
+    Returns
+    -------
+    I : COO array of shape (N, M)
+        An array where all elements are equal to zero, except for the `k`-th
+        diagonal, whose values are equal to one.
+
+    Examples
+    --------
+    >>> eye(2, dtype=int).todense()  # doctest: +NORMALIZE_WHITESPACE
+    array([[1, 0],
+           [0, 1]])
+    >>> eye(3, k=1).todense()  # doctest: +NORMALIZE_WHITESPACE
+    array([[0., 1., 0.],
+           [0., 0., 1.],
+           [0., 0., 0.]])
+    """
+    from .core import COO
+
+    if M is None:
+        M = N
+
+    N = int(N)
+    M = int(M)
+    k = int(k)
+
+    data_length = min(N, M)
+
+    if k > 0:
+        data_length = max(min(data_length, M - k), 0)
+        n_coords = np.arange(data_length)
+        m_coords = n_coords + k
+    elif k < 0:
+        data_length = max(min(data_length, N + k), 0)
+        m_coords = np.arange(data_length)
+        n_coords = m_coords - k
+    else:
+        n_coords = m_coords = np.arange(data_length)
+
+    coords = np.stack([n_coords, m_coords])
+    data = np.ones(data_length, dtype=dtype)
+
+    return COO(coords, data=data, shape=(N, M), has_duplicates=False)

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1748,3 +1748,11 @@ def test_initialization(ndim):
     with pytest.raises(ValueError, match="shape of `coords`"):
         coords = np.random.randint(10, size=20).reshape(1, 20)
         COO(coords, data=data, shape=shape)
+
+
+@pytest.mark.parametrize('N, M', [(4, None), (4, 10), (10, 4), (0, 10)])
+def test_eye(N, M):
+    m = M or N
+    for k in [0, N - 2, N + 2, m - 2, m + 2]:
+        assert_eq(sparse.eye(N, M=M, k=k), np.eye(N, M=M, k=k))
+        assert_eq(sparse.eye(N, M=M, k=k, dtype='i4'), np.eye(N, M=M, k=k, dtype='i4'))

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1768,3 +1768,15 @@ def test_zeros_like():
     x = np.ones((5, 5), dtype='i8')
     assert_eq(sparse.zeros_like(x), np.zeros_like(x))
     assert_eq(sparse.zeros_like(x, dtype='f8'), np.zeros_like(x, dtype='f8'))
+
+
+def test_ones():
+    assert_eq(sparse.ones(5), np.ones(5))
+    assert_eq(sparse.ones((5, 4)), np.ones((5, 4)))
+    assert_eq(sparse.ones((5, 4), dtype='i4'), np.ones((5, 4), dtype='i4'))
+
+
+def test_ones_like():
+    x = np.zeros((5, 5), dtype='i8')
+    assert_eq(sparse.ones_like(x), np.ones_like(x))
+    assert_eq(sparse.ones_like(x, dtype='f8'), np.ones_like(x, dtype='f8'))

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1762,3 +1762,9 @@ def test_zeros():
     assert_eq(sparse.zeros(5), np.zeros(5))
     assert_eq(sparse.zeros((5, 4)), np.zeros((5, 4)))
     assert_eq(sparse.zeros((5, 4), dtype='i4'), np.zeros((5, 4), dtype='i4'))
+
+
+def test_zeros_like():
+    x = np.ones((5, 5), dtype='i8')
+    assert_eq(sparse.zeros_like(x), np.zeros_like(x))
+    assert_eq(sparse.zeros_like(x, dtype='f8'), np.zeros_like(x, dtype='f8'))

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1756,3 +1756,9 @@ def test_eye(N, M):
     for k in [0, N - 2, N + 2, m - 2, m + 2]:
         assert_eq(sparse.eye(N, M=M, k=k), np.eye(N, M=M, k=k))
         assert_eq(sparse.eye(N, M=M, k=k, dtype='i4'), np.eye(N, M=M, k=k, dtype='i4'))
+
+
+def test_zeros():
+    assert_eq(sparse.zeros(5), np.zeros(5))
+    assert_eq(sparse.zeros((5, 4)), np.zeros((5, 4)))
+    assert_eq(sparse.zeros((5, 4), dtype='i4'), np.zeros((5, 4), dtype='i4'))


### PR DESCRIPTION
Add implementations of `eye`, `zeros`, and `zeros_like`, mirroring the equivalent numpy api.