### PR TITLE
Fixup pickle, add copy

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+* :feature:`184` Added :code:`COO.copy` method, and changed pickle of :object:`COO` to not include its cache.
 * :feature:`183` Added :code:`sparse.eye`, :code:`sparse.zeros`,
   :code:`sparse.zeros_like`, :code:`sparse.ones`, and :code:`sparse.ones_like`.
 * :release:`0.4.1 <2018-09-12>`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-* :feature:`184` Added :code:`COO.copy` method, and changed pickle of :object:`COO` to not include its cache.
+* :feature:`184` Added :code:`COO.copy` method, and changed pickle of :code:`COO` to not include its cache.
 * :feature:`183` Added :code:`sparse.eye`, :code:`sparse.zeros`,
   :code:`sparse.zeros_like`, :code:`sparse.ones`, and :code:`sparse.ones_like`.
 * :release:`0.4.1 <2018-09-12>`

--- a/docs/generated/sparse.COO.copy.rst
+++ b/docs/generated/sparse.COO.copy.rst
@@ -1,0 +1,6 @@
+COO\.copy
+=========
+
+.. currentmodule:: sparse
+
+.. automethod:: COO.copy

--- a/docs/generated/sparse.COO.rst
+++ b/docs/generated/sparse.COO.rst
@@ -63,6 +63,7 @@ COO
    .. autosummary::
       :toctree:
 
+      COO.copy
       COO.dot
       COO.reshape
       COO.transpose

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -1,3 +1,4 @@
+import copy as _copy
 from collections import Iterable, Iterator, Sized, defaultdict, deque
 
 import numpy as np
@@ -236,6 +237,24 @@ class COO(SparseArray, NDArrayOperatorsMixin):
 
         if has_duplicates:
             self._sum_duplicates()
+
+    def __getstate__(self):
+        return (self.coords, self.data, self.shape, self.fill_value)
+
+    def __setstate__(self, state):
+        self.coords, self.data, self.shape, self.fill_value = state
+        self._cache = None
+
+    def copy(self, deep=True):
+        """Return a copy of the array.
+
+        Parameters
+        ----------
+        deep : boolean, optional
+            If True (default), the internal coords and data arrays are also
+            copied. Set to ``False`` to only make a shallow copy.
+        """
+        return _copy.deepcopy(self) if deep else _copy.copy(self)
 
     def _make_shallow_copy_of(self, other):
         self.coords = other.coords

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1746,26 +1746,19 @@ def test_pickle():
     assert x2._cache is None
 
 
-def test_copy():
+@pytest.mark.parametrize('deep', [True, False])
+def test_copy(deep):
     x = sparse.COO.from_numpy([1, 0, 0, 0, 0]).reshape((5, 1))
     # Enable caching and add some data to it
     x.enable_caching()
     x.T
     assert x._cache is not None
 
-    # Deep copy
-    x2 = x.copy()
+    x2 = x.copy(deep)
     assert_eq(x, x2)
-    assert x2.data is not x.data
-    assert x2.coords is not x.coords
+    assert (x2.data is x.data) is not deep
+    assert (x2.coords is x.coords) is not deep
     assert x2._cache is None
-
-    # Shallow copy
-    x3 = x.copy(deep=False)
-    assert_eq(x, x3)
-    assert x3.data is x.data
-    assert x3.coords is x.coords
-    assert x3._cache is None
 
 
 @pytest.mark.parametrize("ndim", [2, 3, 4, 5])

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1,4 +1,5 @@
 import operator
+import pickle
 
 import numpy as np
 import pytest
@@ -1731,6 +1732,40 @@ class TestFailFillValue(object):
 
         with pytest.raises(ValueError):
             sparse.concatenate([xs, ys])
+
+
+def test_pickle():
+    x = sparse.COO.from_numpy([1, 0, 0, 0, 0]).reshape((5, 1))
+    # Enable caching and add some data to it
+    x.enable_caching()
+    x.T
+    assert x._cache is not None
+    # Pickle sends data but not cache
+    x2 = pickle.loads(pickle.dumps(x))
+    assert_eq(x, x2)
+    assert x2._cache is None
+
+
+def test_copy():
+    x = sparse.COO.from_numpy([1, 0, 0, 0, 0]).reshape((5, 1))
+    # Enable caching and add some data to it
+    x.enable_caching()
+    x.T
+    assert x._cache is not None
+
+    # Deep copy
+    x2 = x.copy()
+    assert_eq(x, x2)
+    assert x2.data is not x.data
+    assert x2.coords is not x.coords
+    assert x2._cache is None
+
+    # Shallow copy
+    x3 = x.copy(deep=False)
+    assert_eq(x, x3)
+    assert x3.data is x.data
+    assert x3.coords is x.coords
+    assert x3._cache is None
 
 
 @pytest.mark.parametrize("ndim", [2, 3, 4, 5])


### PR DESCRIPTION
- Fixes pickle of `COO` to exclude the `_cache` attribute
- Adds a `COO.copy` method to mirror numpy.