### PR TITLE
Remove `releases` sphinx extension

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,56 +1,85 @@
 Changelog
 =========
 
-* :feature:`185` Added :code:`COO.clip` method.
-* :feature:`184` Added :code:`COO.copy` method, and changed pickle of :code:`COO` to not include its cache.
-* :feature:`183` Added :code:`sparse.eye`, :code:`sparse.zeros`,
-  :code:`sparse.zeros_like`, :code:`sparse.ones`, and :code:`sparse.ones_like`.
-* :release:`0.4.1 <2018-09-12>`
-* :feature:`124` (via :issue:`182`) Allow mixed :code:`ndarray`-:obj:`COO` operations if the result is sparse.
-* :feature:`179` (via :issue:`180`) Allow specifying a fill-value when converting from NumPy arrays.
-* :feature:`175` Added :code:`COO.any` and :code:`COO.all` methods.
-* :feature:`172` Indexing for :code:`COO` now accepts a single one-dimensional array index.
-* :feature:`165` The fill-value can now be something other than zero or :code:`False`.
-* :feature:`160` Added a :code:`sparse.roll` function.
-* :feature:`159` Numba code now releases the GIL. This leads to better multi-threaded performance in Dask.
-* :bug:`158` A number of bugs occurred, so to resolve them, :code:`COO.coords.dtype` is always :code:`np.int64`.
-  :code:`COO`, therefore, uses more memory than before.
-* :feature:`153` (via :issue:`154`) Add support for saving and loading :code:`COO` files from disk
-* :feature:`145` (via :issue:`148`) Support :code:`COO.nonzero` and :code:`np.argwhere`
-* :feature:`80` (via :issue:`146`) Allow faux in-place operations
-* :support:`141` :code:`COO` is now always canonical
-* :feature:`128` Improve indexing performance
-* :feature:`127` Improve element-wise performance
-* :feature:`117` (via :issue:`118`) Reductions now support a negative axis.
-* :bug:`107` (via :issue:`108`) Match behaviour of :code:`ufunc.reduce` from NumPy
-* :release:`0.3.1 <2018-04-12>`
-* :bug:`138` Fix packaging error.
-* :release:`0.3.0 <2018-02-22>`
-* :feature:`102` Add NaN-skipping aggregations
-* :feature:`102` Add equivalent to :code:`np.where`
-* :feature:`98` N-input universal functions now work
-* :feature:`96` Make :code:`dot` more consistent with NumPy
-* :support:`92` Create a base class :code:`SparseArray`
-* :support:`90` Minimum NumPy version is now 1.13
-* :bug:`93` (via :issue:`94`) Fix a bug where setting a :code:`DOK` element to zero did nothing.
-* :release:`0.2.0 <2018-01-25>`
-* :feature:`87` Support faster :code:`np.array(COO)`
-* :feature:`85` Add :code:`DOK` type
-* :bug:`82` (via :issue:`83`) Fix sum for large arrays
-* :feature:`69` Support :code:`.size` and :code:`.density`
-* :support:`43` Documentation added for the package
-* :support:`70` Minimum required SciPy version is now 0.19
-* :feature:`68` :code:`len(COO)` now works
-* :feature:`67` :code:`scalar op COO` now works for all operators
-* :bug:`61` Validate axes for :code:`.transpose()`
-* :feature:`57` Extend indexing support
-* :feature:`41` Add :code:`random` function for generating random sparse arrays
-* :feature:`55` :code:`COO(COO)` now copies the original object
-* :feature:`49` NumPy universal functions and reductions now work on :code:`COO` arrays
-* :bug:`32` (via :issue:`51`) Fix concatenate and stack for large arrays
-* :bug:`47` (via :issue:`48`) Fix :code:`nnz` for scalars
-* :feature:`46` Support more operators and remove all special cases
-* :feature:`40` Add support for :code:`triu` and :code:`tril`
-* :feature:`37` Add support for Ellipsis (:code:`...`) and :code:`None` when indexing
-* :feature:`38` Add support for bitwise bindary operations like :code:`&` and :code:`|`
-* :feature:`35` Support broadcasting in element-wise operations
+Upcoming Release
+----------------
+
+* Added :code:`COO.clip` method (:pr:`185`).
+* Added :code:`COO.copy` method, and changed pickle of :code:`COO` to not
+  include its cache (:pr:`184`).
+* Added :code:`sparse.eye`, :code:`sparse.zeros`, :code:`sparse.zeros_like`,
+  :code:`sparse.ones`, and :code:`sparse.ones_like` (:pr:`183`).
+
+0.4.1 / 2018-09-12
+------------------
+
+* Allow mixed :code:`ndarray`-:code:`COO` operations if the result is sparse
+  (:issue:`124`, via :pr:`182`).
+* Allow specifying a fill-value when converting from NumPy arrays
+  (:issue:`179`, via :pr:`180`).
+* Added :code:`COO.any` and :code:`COO.all` methods (:pr:`175`).
+* Indexing for :code:`COO` now accepts a single one-dimensional array index
+  (:pr:`172`).
+* The fill-value can now be something other than zero or :code:`False`
+  (:pr:`165`).
+* Added a :code:`sparse.roll` function (:pr:`160`).
+* Numba code now releases the GIL. This leads to better multi-threaded
+  performance in Dask (:pr:`159`).
+* A number of bugs occurred, so to resolve them, :code:`COO.coords.dtype` is
+  always :code:`np.int64`.  :code:`COO`, therefore, uses more memory than
+  before (:pr:`158`).
+* Add support for saving and loading :code:`COO` files from disk (:issue:`153`,
+  via :pr:`154`).
+* Support :code:`COO.nonzero` and :code:`np.argwhere` (:issue:`145`, via
+  :pr:`148`).
+* Allow faux in-place operations (:issue:`80`, via :pr:`146`).
+* :code:`COO` is now always canonical (:pr:`141`).
+* Improve indexing performance (:pr:`128`).
+* Improve element-wise performance (:pr:`127`).
+* Reductions now support a negative axis (:issue:`117`, via :pr:`118`).
+* Match behaviour of :code:`ufunc.reduce` from NumPy (:issue:`107`, via
+  :pr:`108`).
+
+0.3.1 / 2018-04-12
+------------------
+
+* Fix packaging error (:pr:`138`).
+
+0.3.0 / 2018-02-22
+------------------
+
+* Add NaN-skipping aggregations (:pr:`102`).
+* Add equivalent to :code:`np.where` (:pr:`102`).
+* N-input universal functions now work (:pr:`98`).
+* Make :code:`dot` more consistent with NumPy (:pr:`96`).
+* Create a base class :code:`SparseArray` (:pr:`92`).
+* Minimum NumPy version is now 1.13 (:pr:`90`).
+* Fix a bug where setting a :code:`DOK` element to zero did nothing
+  (:issue:`93`, via :pr:`94`).
+
+0.2.0 / 2018-01-25
+------------------
+
+* Support faster :code:`np.array(COO)` (:pr:`87`).
+* Add :code:`DOK` type (:pr:`85`).
+* Fix sum for large arrays (:issue:`82`, via :pr:`83`).
+* Support :code:`.size` and :code:`.density` (:pr:`69`).
+* Documentation added for the package (:pr:`43`).
+* Minimum required SciPy version is now 0.19 (:pr:`70`).
+* :code:`len(COO)` now works (:pr:`68`).
+* :code:`scalar op COO` now works for all operators (:pr:`67`).
+* Validate axes for :code:`.transpose()` (:pr:`61`).
+* Extend indexing support (:pr:`57`).
+* Add :code:`random` function for generating random sparse arrays (:pr:`41`).
+* :code:`COO(COO)` now copies the original object (:pr:`55`).
+* NumPy universal functions and reductions now work on :code:`COO` arrays
+  (:pr:`49`).
+* Fix concatenate and stack for large arrays (:issue:`32`, via :pr:`51`).
+* Fix :code:`nnz` for scalars (:issue:`47`, via :pr:`48`).
+* Support more operators and remove all special cases (:pr:`46`).
+* Add support for :code:`triu` and :code:`tril` (:pr:`40`).
+* Add support for Ellipsis (:code:`...`) and :code:`None` when indexing
+  (:pr:`37`).
+* Add support for bitwise bindary operations like :code:`&` and :code:`|`
+  (:pr:`38`).
+* Support broadcasting in element-wise operations (:pr:`35`).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,6 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.extlinks',
-    'releases',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -186,4 +185,7 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None)
 }
 
-releases_github_path = 'pydata/sparse'
+extlinks = {
+    'issue': ('https://github.com/pydata/sparse/issues/%s', 'Issue #'),
+    'pr': ('https://github.com/pydata/sparse/pull/%s', 'PR #')
+}

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ extras_require = {
     'docs': [
         'sphinx',
         'sphinx_rtd_theme',
-        'releases',
     ],
     'tox': [
         'tox',


### PR DESCRIPTION
Formatting changelog manually gives us more control over the output.

Also cleaned up formatting and links to old PRs to more accurately reflect their PR/issue nature.

Fixes #187.