### PR TITLE
A few tweaks to pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
-addopts = --flake8 --doctest-modules sparse --cov-report term-missing --cov-report html --cov sparse --cov-config .coveragerc --junitxml=test_results/pytest/test_results.xml
+addopts = --flake8 --doctest-modules --cov-report term-missing --cov-report html --cov sparse --cov-config .coveragerc --junitxml=test_results/pytest/test_results.xml
+filterwarnings =
+    ignore::PendingDeprecationWarning
+testpaths = sparse


### PR DESCRIPTION
- Don't specify path in addopts. Having the filepath here prevents users from specifying specific test files or test functions easily. By using testpaths instead, running `py.test` with no args still works.

- Ignore all `PendingDeprecationWarning` warnings with filterwarnings.  These are turned off by default in python, but pytest's warning plugin removes that filter, polluting our test output. Since these warnings are from numpy, and aren't visible to users by default anyway, we should just ignore them in our test output as well (scipy also does this). This removes a large amount of noise from our test logs.