### PR TITLE
Add order parameter to `COO.reshape`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 Upcoming Release
 ----------------
 
+* Added :code:`order` parameter to :code:`COO.reshape` to make it work with
+  :code:`np.reshape` (:pr:`193`).
 * Added :code:`COO.mean` and :code:`sparse.nanmean` (:pr:`190`).
 * Added :code:`sparse.full` and :code:`sparse.full_like` (:pr:`189`).
 * Added :code:`COO.clip` method (:pr:`185`).

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -1394,7 +1394,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         from .common import linear_loc
         return linear_loc(self.coords, self.shape)
 
-    def reshape(self, shape):
+    def reshape(self, shape, order='C'):
         """
         Returns a new :obj:`COO` array that is a reshaped version of this array.
 
@@ -1412,6 +1412,11 @@ class COO(SparseArray, NDArrayOperatorsMixin):
         --------
         numpy.ndarray.reshape : The equivalent Numpy function.
 
+        Notes
+        -----
+        The :code:`order` parameter is provided just for compatibility with
+        Numpy and isn't actually supported.
+
         Examples
         --------
         >>> s = COO.from_numpy(np.arange(25))
@@ -1427,6 +1432,9 @@ class COO(SparseArray, NDArrayOperatorsMixin):
             shape = tuple(shape)
         else:
             shape = (shape,)
+
+        if order not in {'C', None}:
+            raise NotImplementedError("The `order` parameter is not supported")
 
         if self.shape == shape:
             return self

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -229,10 +229,6 @@ def test_reshape_function():
     assert isinstance(s2, COO)
     assert_eq(s2, x.reshape(shape))
 
-    # order parameter not actually supported
-    with pytest.raises(NotImplementedError):
-        np.reshape(s, shape, order='F')
-
 
 def test_to_scipy_sparse():
     s = sparse.random((3, 5), density=0.5)

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -220,6 +220,20 @@ def test_reshape_same():
     assert s.reshape(s.shape) is s
 
 
+def test_reshape_function():
+    s = sparse.random((5, 3), density=0.5)
+    x = s.todense()
+    shape = (3, 5)
+
+    s2 = np.reshape(s, shape)
+    assert isinstance(s2, COO)
+    assert_eq(s2, x.reshape(shape))
+
+    # order parameter not actually supported
+    with pytest.raises(NotImplementedError):
+        np.reshape(s, shape, order='F')
+
+
 def test_to_scipy_sparse():
     s = sparse.random((3, 5), density=0.5)
     a = s.to_scipy_sparse()


### PR DESCRIPTION
Adds support for `np.reshape` to dispatch to `COO.reshape` properly.