### PR TITLE
added fast escape for tensordot() when nnz == 0

### DIFF
--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -149,6 +149,11 @@ def tensordot(a, b, axes=2):
     newshape_b = (N2, -1)
     oldb = [bs[axis] for axis in notin]
 
+    # if either a or b is all zeros, we can just return a zeros COO
+    if ((isinstance(a, (COO, scipy.sparse.spmatrix)) and a.nnz == 0) or
+        (isinstance(b, (COO, scipy.sparse.spmatrix)) and b.nnz == 0)):
+        return zeros(tuple(olda + oldb))
+
     at = a.transpose(newaxes_a).reshape(newshape_a)
     bt = b.transpose(newaxes_b).reshape(newshape_b)
     res = _dot(at, bt)

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -272,6 +272,14 @@ def test_tensordot(a_shape, b_shape, axes):
     # assert isinstance(sparse.tensordot(a, sb, axes), COO)
 
 
+def test_tensordot_zeros():
+    sa = sparse.zeros((9999999999,))
+    sb = sparse.zeros((9999999999,))
+    c = sparse.tensordot(sa, sb)
+    assert 0 == c.nnz
+    assert (9999999999, 9999999999) == c.shape
+
+
 @pytest.mark.parametrize('a_shape, b_shape', [
     ((3, 1, 6, 5), (2, 1, 4, 5, 6)),
     ((2, 1, 4, 5, 6), (3, 1, 6, 5)),


### PR DESCRIPTION
This way we don't convert to CSR or CSC if we don't need to.