### PR TITLE
Fix collections-related DeprecationWarnings on import

### DIFF
--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -1,7 +1,10 @@
 from functools import reduce, wraps
 import operator
 import warnings
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except AttributeError:
+    from collections import Iterable
 
 import numpy as np
 import scipy.sparse

--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -3,7 +3,7 @@ import operator
 import warnings
 try:
     from collections.abc import Iterable
-except AttributeError:
+except (AttributeError, ImportError):
     from collections import Iterable
 
 import numpy as np

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -2,7 +2,7 @@ import copy as _copy
 import operator
 try:
     from collections.abc import Iterable, Iterator, Sized
-except AttributeError:
+except (AttributeError, ImportError):
     from collections import Iterable, Iterator, Sized
 from collections import defaultdict, deque
 from functools import reduce

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -1,6 +1,9 @@
 import copy as _copy
 import operator
-from collections import Iterable, Iterator, Sized
+try:
+    from collections.abc import Iterable, Iterator, Sized
+except AttributeError:
+    from collections import Iterable, Iterator, Sized
 from collections import defaultdict, deque
 from functools import reduce
 import warnings

--- a/sparse/slicing.py
+++ b/sparse/slicing.py
@@ -3,7 +3,10 @@
 
 import math
 from numbers import Integral, Number
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except AttributeError:
+    from collections import Iterable
 
 import numpy as np
 

--- a/sparse/slicing.py
+++ b/sparse/slicing.py
@@ -5,7 +5,7 @@ import math
 from numbers import Integral, Number
 try:
     from collections.abc import Iterable
-except AttributeError:
+except (AttributeError, ImportError):
     from collections import Iterable
 
 import numpy as np

--- a/sparse/sparse_array.py
+++ b/sparse/sparse_array.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 from abc import ABCMeta, abstractmethod
 try:
     from collections.abc import Iterable
-except AttributeError:
+except (AttributeError, ImportError):
     from collections import Iterable
 from numbers import Integral
 from functools import reduce

--- a/sparse/sparse_array.py
+++ b/sparse/sparse_array.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, division, print_function
 from abc import ABCMeta, abstractmethod
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except AttributeError:
+    from collections import Iterable
 from numbers import Integral
 from functools import reduce
 import operator

--- a/sparse/utils.py
+++ b/sparse/utils.py
@@ -1,5 +1,8 @@
 import functools
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except AttributeError:
+    from collections import Iterable
 from numbers import Integral
 
 import numpy as np

--- a/sparse/utils.py
+++ b/sparse/utils.py
@@ -1,7 +1,7 @@
 import functools
 try:
     from collections.abc import Iterable
-except AttributeError:
+except (AttributeError, ImportError):
     from collections import Iterable
 from numbers import Integral
 


### PR DESCRIPTION
Currently, when using Python 3.7, one sees the following warning when importing `sparse`:

    .../sparse/sparse/coo/core.py:3: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
      from collections import Iterable, Iterator, Sized

This warning will become an error in Python 3.8, the upcoming version. So it's time to fix it.