### PR TITLE
Add resize method and change reshape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ coverage.xml
 *,cover
 .pytest_cache/
 test_results/
+junit/
 
 # Airspeed velocity
 .asv/

--- a/docs/generated/sparse.COO.resize.rst
+++ b/docs/generated/sparse.COO.resize.rst
@@ -1,0 +1,6 @@
+COO.resize
+==========
+
+.. currentmodule:: sparse
+
+.. automethod:: COO.resize

--- a/docs/generated/sparse.COO.rst
+++ b/docs/generated/sparse.COO.rst
@@ -73,6 +73,7 @@ COO
       COO.copy
       COO.dot
       COO.reshape
+      COO.resize
       COO.transpose
       COO.nonzero
 

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -1753,10 +1753,8 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         else:
             raise ValueError('Invalid input')
         
-        if any(d == -1 for d in shape):
-            extra = int(self.size /
-                        np.prod([d for d in shape if d != -1]))
-            shape = tuple([d if d != -1 else extra for d in shape])
+        if any(d < 0 for d in shape):
+            raise ValueError('negative dimensions not allowed')
         
         # TODO: this self.size enforces a 2**64 limit to array size
         linear_loc = self.linear_loc()

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -1704,9 +1704,9 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
 
         if self.shape == shape:
             return self
-        
+
         if np.prod(self.shape) != np.prod(shape):
-            raise ValueError('cannot reshape array of size {} into shape {}'.format(np.prod(self.shape),shape))
+            raise ValueError('cannot reshape array of size {} into shape {}'.format(np.prod(self.shape), shape))
 
         if self._cache is not None:
             for sh, value in self._cache['reshape']:
@@ -1731,31 +1731,30 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
             self._cache['reshape'].append((shape, result))
         return result
 
-    
-    def resize(self,*args,refcheck=False):
+    def resize(self, *args, refcheck=False):
         """
         This method changes the shape and size of an array in-place.
-        
+
         Parameters
         ----------
         args : tuple, or series of integers
             The desired shape of the output array.
-        
+
         See Also
         --------
         numpy.ndarray.resize : The equivalent Numpy function.
-        
+
         """
-        if len(args)==1 and isinstance(args[0],tuple):
+        if len(args) == 1 and isinstance(args[0], tuple):
             shape = args[0]
-        elif all(isinstance(arg,int) for arg in args):
+        elif all(isinstance(arg, int) for arg in args):
             shape = tuple(args)
         else:
             raise ValueError('Invalid input')
-        
+
         if any(d < 0 for d in shape):
             raise ValueError('negative dimensions not allowed')
-        
+
         # TODO: this self.size enforces a 2**64 limit to array size
         linear_loc = self.linear_loc()
 
@@ -1764,10 +1763,10 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         for i, d in enumerate(shape[::-1]):
             coords[-(i + 1), :] = (linear_loc // strides) % d
             strides *= d
-        
+
         self.shape = shape
         self.coords = coords
-        
+
     def to_scipy_sparse(self):
         """
         Converts this :obj:`COO` object into a :obj:`scipy.sparse.coo_matrix`.

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -226,9 +226,13 @@ def test_transpose_error(axis):
 ])
 def test_resize(a, b):
     s = sparse.random(a, density=0.5)
+    orig_size = s.size
     x = s.todense()
-    x.resize(b)
+    x = np.resize(x, b)
     s.resize(b)
+    temp = x.reshape(x.size)
+    temp[orig_size:] = s.fill_value
+    assert isinstance(s, sparse.SparseArray)
     assert_eq(x, s)
 
 
@@ -1554,16 +1558,16 @@ def test_add_many_sparse_arrays():
 
 
 def test_caching():
-    x = COO({(10, 10, 10): 1})
+    x = COO({(9, 9, 9): 1})
     assert x[:].reshape((100, 10)).transpose().tocsr() is not x[:].reshape((100, 10)).transpose().tocsr()
 
-    x = COO({(10, 10, 10): 1}, cache=True)
+    x = COO({(9, 9, 9): 1}, cache=True)
     assert x[:].reshape((100, 10)).transpose().tocsr() is x[:].reshape((100, 10)).transpose().tocsr()
 
     x = COO({(1, 1, 1, 1, 1, 1, 1, 2): 1}, cache=True)
 
     for i in range(x.ndim):
-        x.reshape((1,) * i + (2,) + (1,) * (x.ndim - i - 1))
+        x.reshape(x.size)
 
     assert len(x._cache['reshape']) < 5
 

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -211,25 +211,27 @@ def test_transpose_error(axis):
     with pytest.raises(ValueError):
         x.transpose(axis)
 
+
 @pytest.mark.parametrize('a,b', [
     [(3, 4), (5, 5)],
     [(12,), (3, 4)],
     [(12,), (3, 6)],
-    [(5,5,5), (6,6,6)],
+    [(5, 5, 5), (6, 6, 6)],
     [(3, 4), (9, 4)],
     [(5,), (4,)],
     [(2, 3, 4, 5), (2, 3, 4, 5, 6)],
-    [(100,), (5,5)],
+    [(100,), (5, 5)],
     [(2, 3, 4, 5), (20, 6)],
     [(), ()],
 ])
-def test_resize(a,b):
+def test_resize(a, b):
     s = sparse.random(a, density=0.5)
     x = s.todense()
     x.resize(b)
     s.resize(b)
     assert_eq(x, s)
-        
+
+
 @pytest.mark.parametrize('a,b', [
     [(3, 4), (3, 4)],
     [(12,), (3, 4)],

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -211,7 +211,24 @@ def test_transpose_error(axis):
     with pytest.raises(ValueError):
         x.transpose(axis)
 
+@pytest.mark.parametrize('a,b', [
+    [(3, 4), (5, 5)],
+    [(12,), (3, 4)],
+    [(12,), (3, 6)],
+    [(5,5,5), (6,6,6)],
+    [(3, 4), (9, 4)],
+    [(5,), (4,)],
+    [(2, 3, 4, 5), (2, 3, 4, 5, 6)],
+    [(100,), (5,5)],
+    [(2, 3, 4, 5), (20, 6)],
+    [(), ()],
+])
+def test_resize(a,b):
+    s = sparse.random(a, density=0.5)
+    x = s.todense()
 
+    assert_eq(x.resize(b), s.resize(b))
+        
 @pytest.mark.parametrize('a,b', [
     [(3, 4), (3, 4)],
     [(12,), (3, 4)],

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -226,8 +226,9 @@ def test_transpose_error(axis):
 def test_resize(a,b):
     s = sparse.random(a, density=0.5)
     x = s.todense()
-
-    assert_eq(x.resize(b), s.resize(b))
+    x.resize(b)
+    s.resize(b)
+    assert_eq(x, s)
         
 @pytest.mark.parametrize('a,b', [
     [(3, 4), (3, 4)],


### PR DESCRIPTION
I added a validation check in the reshape method for compatibility with numpy. I also added an in-place resize method. I didn't do anything with the refcheck parameter. Just like numpy, the shape can be passed either as a tuple or a series of integers, hence the *args. 

Fixes #241 
Fixes #250