### PR TITLE
Modifications to enable sparse xarrays

### DIFF
--- a/sparse/coo/__init__.py
+++ b/sparse/coo/__init__.py
@@ -5,6 +5,8 @@ from .common import (tensordot, dot, matmul, concatenate, stack, triu, tril, whe
                      eye, full, full_like, zeros, zeros_like, ones, ones_like,
                      kron, argwhere, isposinf, isneginf)
 
+from numpy.core._multiarray_umath import result_type
+
 __all__ = ['COO', 'as_coo', 'elemwise', 'tensordot', 'dot', 'matmul', 'concatenate', 'stack', 'triu', 'tril', 'where', 'nansum', 'nanmean',
            'nanprod', 'nanmin', 'nanmax', 'nanreduce', 'roll', 'eye', 'full', 'full_like', 'zeros', 'zeros_like', 'ones', 'ones_like', 'kron', 'argwhere',
-           'isposinf', 'isneginf']
+           'isposinf', 'isneginf', 'result_type']

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -2066,7 +2066,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         return self.__array_ufunc__(np.clip, '__call__', self, a_min=min,
                                     a_max=max, out=out)
 
-    def astype(self, dtype):
+    def astype(self, dtype, copy=True):
         """
         Copy of the array, cast to a specified type.
 
@@ -2077,7 +2077,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         :obj:`COO.elemwise`: Apply an arbitrary element-wise function to one or two
             arguments.
         """
-        return self.__array_ufunc__(np.ndarray.astype, '__call__', self, dtype=dtype)
+        return self.__array_ufunc__(np.ndarray.astype, '__call__', self, dtype=dtype, copy=copy)
 
     def maybe_densify(self, max_size=1000, min_density=0.25):
         """


### PR DESCRIPTION
Hello!

I'm working on a SciPy sprint to get `sparse` arrays into `xarray`.

With a couple tweaks to xarray anticipating objects implementing `__array_function__`, I can get it to work with the following:

* Make `COO.astype()` provide the [copy](https://github.com/pydata/xarray/blob/23fc0d6f8a5affefb84e5f20dc0bef7ace4542e2/xarray/core/duck_array_ops.py#L135) argument

* Expose [result_type()](https://github.com/pydata/xarray/blob/24d49fcd723f20b09998c302dc6003b8de69e595/xarray/core/dtypes.py#L146) though `sparse` to bypass numpy's dispatcher -- I'm importing the lower level function.

(I'm using numpy 1.16 with `'NUMPY_EXPERIMENTAL_ARRAY_FUNCTION'` = `'1'`
Numpy 1.17.0rc1 currently fails due to an issue with numba https://github.com/numba/numba/issues/4319)