### PR TITLE
__array_function__ suppresses AttributeError

### DIFF
--- a/sparse/sparse_array.py
+++ b/sparse/sparse_array.py
@@ -221,14 +221,15 @@ class SparseArray:
             for submodule in submodules:
                 module = getattr(module, submodule)
             sparse_func = getattr(module, func.__name__)
-            return sparse_func(*args, **kwargs)
         except AttributeError:
             pass
+        else:
+            return sparse_func(*args, **kwargs)
 
-        if not hasattr(type(self), func.__name__):
+        try:
+            sparse_func = getattr(type(self), func.__name__)
+        except AttributeError:
             return NotImplemented
-
-        sparse_func = getattr(type(self), func.__name__)
 
         if not isinstance(sparse_func, Callable):
             return getattr(self, func.__name__)


### PR DESCRIPTION
Fix bug where any of the top-level functions invoked by ``COO.__array_function__`` raises AttributeError for any reason, but the exception is improperly suppressed and ``__array_function__`` returns NotImplemented instead.