### PR TITLE
__array_function__ test coverage; numpy 1.17; result_type()

### DIFF
--- a/docs/generated/sparse.result_type.rst
+++ b/docs/generated/sparse.result_type.rst
@@ -1,0 +1,6 @@
+result_type
+===========
+
+.. currentmodule:: sparse
+
+.. autofunction:: result_type

--- a/docs/generated/sparse.rst
+++ b/docs/generated/sparse.rst
@@ -67,6 +67,8 @@ API
 
     random
 
+    result_type
+
     roll
 
     save_npz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy<=1.16
+numpy
 scipy>=0.19
 numba>=0.39

--- a/sparse/__init__.py
+++ b/sparse/__init__.py
@@ -8,10 +8,3 @@ from .io import save_npz, load_npz
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
-
-import os
-
-_AUTO_DENSIFICATION_ENABLED = bool(int(os.environ.get('SPARSE_AUTO_DENSIFY', '0')))
-_AUTO_WARN_ON_TOO_DENSE = bool(int(os.environ.get('SPARSE_WARN_ON_TOO_DENSE', '0')))
-
-del os

--- a/sparse/coo/__init__.py
+++ b/sparse/coo/__init__.py
@@ -3,10 +3,7 @@ from .umath import elemwise
 from .common import (tensordot, dot, matmul, concatenate, stack, triu, tril, where,
                      nansum, nanmean, nanprod, nanmin, nanmax, nanreduce, roll,
                      eye, full, full_like, zeros, zeros_like, ones, ones_like,
-                     kron, argwhere, isposinf, isneginf)
-
-# Allow applying np.result_type to a COO through __array_function__
-from numpy.core._multiarray_umath import result_type
+                     kron, argwhere, isposinf, isneginf, result_type)
 
 __all__ = ['COO', 'as_coo', 'elemwise', 'tensordot', 'dot', 'matmul', 'concatenate', 'stack', 'triu', 'tril', 'where', 'nansum', 'nanmean',
            'nanprod', 'nanmin', 'nanmax', 'nanreduce', 'roll', 'eye', 'full', 'full_like', 'zeros', 'zeros_like', 'ones', 'ones_like', 'kron', 'argwhere',

--- a/sparse/coo/__init__.py
+++ b/sparse/coo/__init__.py
@@ -5,6 +5,9 @@ from .common import (tensordot, dot, matmul, concatenate, stack, triu, tril, whe
                      eye, full, full_like, zeros, zeros_like, ones, ones_like,
                      kron, argwhere, isposinf, isneginf)
 
+# Allow applying np.result_type to a COO through __array_function__
+from numpy.core._multiarray_umath import result_type
+
 __all__ = ['COO', 'as_coo', 'elemwise', 'tensordot', 'dot', 'matmul', 'concatenate', 'stack', 'triu', 'tril', 'where', 'nansum', 'nanmean',
            'nanprod', 'nanmin', 'nanmax', 'nanreduce', 'roll', 'eye', 'full', 'full_like', 'zeros', 'zeros_like', 'ones', 'ones_like', 'kron', 'argwhere',
-           'isposinf', 'isneginf']
+           'isposinf', 'isneginf', 'result_type']

--- a/sparse/coo/common.py
+++ b/sparse/coo/common.py
@@ -1397,3 +1397,23 @@ def isneginf(x, out=None):
     """
     from .core import elemwise
     return elemwise(lambda x, out=None, dtype=None: np.isneginf(x, out=out), x, out=out)
+
+
+def result_type(*arrays_and_dtypes):
+    """Returns the type that results from applying the NumPy type promotion rules to the
+    arguments.
+
+    See Also
+    --------
+    numpy.result_type : The NumPy equivalent
+    """
+    return np.result_type(*(_as_result_type_arg(x) for x in arrays_and_dtypes))
+
+
+def _as_result_type_arg(x):
+    if not isinstance(x, SparseArray):
+        return x
+    if x.ndim > 0:
+        return x.dtype
+    # 0-dimensional arrays give different result_type outputs than their dtypes
+    return x.todense()

--- a/sparse/coo/core.py
+++ b/sparse/coo/core.py
@@ -246,8 +246,8 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
                                             self.coords.shape[0],
                                             self.coords.shape))
 
-        from .. import _AUTO_WARN_ON_TOO_DENSE
-        if _AUTO_WARN_ON_TOO_DENSE and self.nbytes >= self.size * self.data.itemsize:
+        from ..settings import WARN_ON_TOO_DENSE
+        if WARN_ON_TOO_DENSE and self.nbytes >= self.size * self.data.itemsize:
             warnings.warn("Attempting to create a sparse array that takes no less "
                           "memory than than an equivalent dense array. You may want to "
                           "use a dense array here instead.", RuntimeWarning)

--- a/sparse/settings.py
+++ b/sparse/settings.py
@@ -1,0 +1,21 @@
+import os
+import numpy
+
+
+AUTO_DENSIFY = bool(int(os.environ.get('SPARSE_AUTO_DENSIFY', '0')))
+WARN_ON_TOO_DENSE = bool(int(os.environ.get('SPARSE_WARN_ON_TOO_DENSE', '0')))
+
+
+def _is_nep18_enabled():
+
+    class A:
+        def __array_function__(self, *args, **kwargs):
+            return True
+
+    try:
+        return numpy.concatenate([A()])
+    except ValueError:
+        return False
+
+
+NEP18_ENABLED = _is_nep18_enabled()

--- a/sparse/sparse_array.py
+++ b/sparse/sparse_array.py
@@ -207,8 +207,8 @@ class SparseArray:
         """
 
     def __array__(self, **kwargs):
-        from . import _AUTO_DENSIFICATION_ENABLED as densify
-        if not densify:
+        from .settings import AUTO_DENSIFY
+        if not AUTO_DENSIFY:
             raise RuntimeError('Cannot convert a sparse array to dense automatically. '
                                'To manually densify, use the todense method.')
 

--- a/tests/test_array_function.py
+++ b/tests/test_array_function.py
@@ -1,21 +1,11 @@
 import sparse
+from sparse.settings import NEP18_ENABLED
 from sparse.utils import assert_eq
 import numpy as np
 import pytest
 
 
-def is_nep18_active():
-    class A():
-        def __array_function__(self, *args, **kwargs):
-            return True
-
-    try:
-        return np.concatenate([A()])
-    except ValueError:
-        return False
-
-
-if not is_nep18_active():
+if not NEP18_ENABLED:
     pytest.skip(
         "NEP18 is not enabled", allow_module_level=True
     )

--- a/tests/test_array_function.py
+++ b/tests/test_array_function.py
@@ -67,12 +67,12 @@ def test_stack():
 
 
 @pytest.mark.parametrize('arg_order', [
-    pytest.param((0, 0, 1), marks=pytest.mark.xfail),
+    pytest.param((0, 0, 1), marks=pytest.mark.xfail(reason="#271")),
     (0, 1, 0),
     (0, 1, 1),
-    pytest.param((1, 0, 0), marks=pytest.mark.xfail),
+    pytest.param((1, 0, 0), marks=pytest.mark.xfail(reason="#271")),
     (1, 0, 1),
-    pytest.param((1, 1, 0), marks=pytest.mark.xfail),
+    pytest.param((1, 1, 0), marks=pytest.mark.xfail(reason="#271")),
     (1, 1, 1),
 ])
 @pytest.mark.parametrize('func', [

--- a/tests/test_array_function.py
+++ b/tests/test_array_function.py
@@ -71,12 +71,12 @@ def test_stack():
 
 
 @pytest.mark.parametrize('arg_order', [
-    pytest.param((0, 0, 1), marks=pytest.mark.xfail(reason="#271")),
+    (0, 0, 1),
     (0, 1, 0),
     (0, 1, 1),
-    pytest.param((1, 0, 0), marks=pytest.mark.xfail(reason="#271")),
+    (1, 0, 0),
     (1, 0, 1),
-    pytest.param((1, 1, 0), marks=pytest.mark.xfail(reason="#271")),
+    (1, 1, 0),
     (1, 1, 1),
 ])
 @pytest.mark.parametrize('func', [

--- a/tests/test_array_function.py
+++ b/tests/test_array_function.py
@@ -1,30 +1,74 @@
+import os
 import sparse
 from sparse.utils import assert_eq
-import os
 import pytest
 np = pytest.importorskip('numpy', minversion='1.16')
 
 
 env_name = "NUMPY_EXPERIMENTAL_ARRAY_FUNCTION"
 
+if np.__version__ < "1.17":
+    array_function_env = os.getenv(env_name, "0")
+else:
+    array_function_env = os.getenv(env_name, "1")
 
-@pytest.mark.skipif(env_name not in os.environ or os.environ[env_name] != "1",
-                    reason=env_name + " undefined or disabled")
+if array_function_env != "1":
+    pytest.skip(
+        "NUMPY_EXPERIMENTAL_ARRAY_FUNCTION is not enabled", allow_module_level=True
+    )
+
+
 @pytest.mark.parametrize('func', [
-    lambda x: np.dot(x, x),
-    lambda x: np.mean(x),
-    lambda x: np.std(x),
-    lambda x: np.var(x),
-    lambda x: np.sum(x),
+    np.mean,
+    np.std,
+    np.var,
+    np.sum,
     lambda x: np.sum(x, axis=0),
-    lambda x: np.stack([x, x]),
-    lambda x: np.tensordot(x, x),
-    lambda x: np.transpose(x),
-    lambda x: np.where(x > np.transpose(x), x, np.transpose(x))
+    np.transpose,
 ])
-def test_array_function(func):
-    x = sparse.random((50, 50), density=.25)
-    y = x.todense()
+def test_unary(func):
+    y = sparse.random((50, 50), density=.25)
+    x = y.todense()
     xx = func(x)
     yy = func(y)
+    assert_eq(xx, yy)
+
+
+@pytest.mark.parametrize('arg_order', [
+    (0, 1), (1, 0), (1, 1)
+])
+@pytest.mark.parametrize('func', [
+    np.dot,
+    lambda x, y: np.stack([x, y]),
+    np.matmul,
+    np.result_type,
+    np.tensordot,
+])
+def test_binary(func, arg_order):
+    y = sparse.random((50, 50), density=.25)
+    x = y.todense()
+    xx = func(x, x)
+    args = [(x, y)[i] for i in arg_order]
+    yy = func(*args)
+
+    if isinstance(xx, np.ndarray):
+        assert_eq(xx, yy)
+    else:
+        # result_type returns a dtype
+        assert xx == yy
+
+
+@pytest.mark.parametrize('arg_order', [
+    (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0),
+    (1, 0, 1), (1, 1, 0), (1, 1, 1)
+])
+@pytest.mark.parametrize('func', [
+    lambda a, b, c: np.where(a.astype(bool), b, c),
+])
+def test_ternary(func, arg_order):
+    y = sparse.random((50, 50), density=.25)
+    x = y.todense()
+    xx = func(x, x, x)
+    args = [(x, y)[i] for i in arg_order]
+    yy = func(*args)
     assert_eq(xx, yy)

--- a/tests/test_array_function.py
+++ b/tests/test_array_function.py
@@ -25,7 +25,6 @@ if array_function_env != "1":
     np.sum,
     lambda x: np.sum(x, axis=0),
     lambda x: np.transpose(x),
-    lambda x: np.matmul(x, x)
 ])
 def test_unary(func):
     y = sparse.random((50, 50), density=.25)
@@ -42,6 +41,7 @@ def test_unary(func):
     np.dot,
     np.result_type,
     np.tensordot,
+    np.matmul,
 ])
 def test_binary(func, arg_order):
     y = sparse.random((50, 50), density=.25)

--- a/tests/test_array_function.py
+++ b/tests/test_array_function.py
@@ -39,8 +39,6 @@ def test_unary(func):
 ])
 @pytest.mark.parametrize('func', [
     np.dot,
-    lambda x, y: np.stack([x, y]),
-    np.matmul,
     np.result_type,
     np.tensordot,
 ])
@@ -58,9 +56,24 @@ def test_binary(func, arg_order):
         assert xx == yy
 
 
+def test_stack():
+    """stack(), by design, does not allow for mixed type inputs
+    """
+    y = sparse.random((50, 50), density=.25)
+    x = y.todense()
+    xx = np.stack([x, x])
+    yy = np.stack([y, y])
+    assert_eq(xx, yy)
+
+
 @pytest.mark.parametrize('arg_order', [
-    (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0),
-    (1, 0, 1), (1, 1, 0), (1, 1, 1)
+    pytest.param((0, 0, 1), marks=pytest.mark.xfail),
+    (0, 1, 0),
+    (0, 1, 1),
+    pytest.param((1, 0, 0), marks=pytest.mark.xfail),
+    (1, 0, 1),
+    pytest.param((1, 1, 0), marks=pytest.mark.xfail),
+    (1, 1, 1),
 ])
 @pytest.mark.parametrize('func', [
     lambda a, b, c: np.where(a.astype(bool), b, c),

--- a/tests/test_array_function.py
+++ b/tests/test_array_function.py
@@ -1,20 +1,23 @@
-import os
 import sparse
 from sparse.utils import assert_eq
+import numpy as np
 import pytest
-np = pytest.importorskip('numpy', minversion='1.16')
 
 
-env_name = "NUMPY_EXPERIMENTAL_ARRAY_FUNCTION"
+def is_nep18_active():
+    class A():
+        def __array_function__(self, *args, **kwargs):
+            return True
 
-if np.__version__ < "1.17":
-    array_function_env = os.getenv(env_name, "0")
-else:
-    array_function_env = os.getenv(env_name, "1")
+    try:
+        return np.concatenate([A()])
+    except ValueError:
+        return False
 
-if array_function_env != "1":
+
+if not is_nep18_active():
     pytest.skip(
-        "NUMPY_EXPERIMENTAL_ARRAY_FUNCTION is not enabled", allow_module_level=True
+        "NEP18 is not enabled", allow_module_level=True
     )
 
 


### PR DESCRIPTION
- Support for numpy 1.17 (it's already what's used in CI today)
- Implement sparse.result_type + unit tests
- Refactor environment variables and other switches into sparse.settings
- Add unit tests for mixed numpy+sparse inputs to ``__array_function__``, with different permutations
