### PR TITLE
Avoid making a copy of `coords`

### DIFF
--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -239,7 +239,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
                 shape = ()
 
         super().__init__(shape, fill_value=fill_value)
-        self.coords = self.coords.astype(np.intp)
+        self.coords = self.coords.astype(np.intp, copy=False)
 
         if self.shape:
             if len(self.data) != self.coords.shape[1]:


### PR DESCRIPTION
Coords is not modified anywhere in this class, so we probably do not need to copy it.

This also would allow for identity short-cuts when performing operations on sparse arrays with the same sparsity pattern.