### PR TITLE
ENH: Add numba extension support for COO objects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,5 +71,10 @@ setup(
         "Source": "https://github.com/pydata/sparse/",
         "Tracker": "https://github.com/pydata/sparse/issues",
     },
+    entry_points={
+        "numba_extensions": [
+            "init = sparse._numba_extension:_init_extension",
+        ],
+    },
     python_requires=">=3.5, <4",
 )

--- a/sparse/_coo/numba_extension.py
+++ b/sparse/_coo/numba_extension.py
@@ -120,43 +120,139 @@ def lower_constant_COO(context, builder, typ, pyval):
         cgutils.pack_struct(builder, (data, coords, shape, fill_value)),
     )
 
+def _unbox_native_field(typ, obj, field_name: str, c):
+    ret_ptr = cgutils.alloca_once(c.builder, c.context.get_value_type(typ))
+    is_error_ptr = cgutils.alloca_once_value(c.builder, cgutils.false_bit)
+    fail_obj = c.context.get_constant_null(typ)
+
+    field_obj = c.pyapi.object_getattr_string(obj, field_name)
+    with c.builder.if_else(cgutils.is_null(c.builder, field_obj), likely=False) as (then, otherwise):
+        with then:
+            c.builder.store(cgutils.true_bit, is_error_ptr)
+            c.builder.store(fail_obj, ret_ptr)
+
+        with otherwise:
+            field_native = c.unbox(typ, field_obj)
+            c.pyapi.decref(field_obj)
+            with c.builder.if_else(field_native.is_error, likely=False) as (then, otherwise):
+                with then:
+                    c.builder.store(cgutils.true_bit, is_error_ptr)
+                    c.builder.store(fail_obj, ret_ptr)
+                with otherwise:
+                    c.builder.store(cgutils.false_bit, is_error_ptr)
+                    c.builder.store(field_native.value, ret_ptr)
+
+    return NativeValue(c.builder.load(ret_ptr), is_error=c.builder.load(is_error_ptr))
+
 
 @unbox(COOType)
 def unbox_COO(typ: COOType, obj: COO, c) -> NativeValue:
-    data = c.pyapi.object_getattr_string(obj, "data")
-    coords = c.pyapi.object_getattr_string(obj, "coords")
-    shape = c.pyapi.object_getattr_string(obj, "shape")
-    fill_value = c.pyapi.object_getattr_string(obj, "fill_value")
-    coo = cgutils.create_struct_proxy(typ)(c.context, c.builder)
-    coo.coords = c.unbox(typ.coords_type, coords).value
-    coo.data = c.unbox(typ.data_type, data).value
-    coo.shape = c.unbox(typ.shape_type, shape).value
-    coo.fill_value = c.unbox(typ.fill_value_type, fill_value).value
-    c.pyapi.decref(data)
-    c.pyapi.decref(coords)
-    c.pyapi.decref(shape)
-    c.pyapi.decref(fill_value)
-    is_error = cgutils.is_not_null(c.builder, c.pyapi.err_occurred())
-    return NativeValue(coo._getvalue(), is_error=is_error)
+    ret_ptr = cgutils.alloca_once(c.builder, c.context.get_value_type(typ))
+    is_error_ptr = cgutils.alloca_once_value(c.builder, cgutils.false_bit)
+    fail_obj = c.context.get_constant_null(typ)
+
+    data = _unbox_native_field(typ.data_type, obj, "data", c)
+    with c.builder.if_else(data.is_error, likely=False) as (then, otherwise):
+        with then:
+            c.builder.store(cgutils.true_bit, is_error_ptr)
+            c.builder.store(fail_obj, ret_ptr)
+        with otherwise:
+            coords = _unbox_native_field(typ.coords_type, obj, "coords", c)
+            with c.builder.if_else(coords.is_error, likely=False) as (then, otherwise):
+                with then:
+                    c.builder.store(cgutils.true_bit, is_error_ptr)
+                    c.builder.store(fail_obj, ret_ptr)
+                with otherwise:
+                    shape = _unbox_native_field(typ.shape_type, obj, "shape", c)
+                    with c.builder.if_else(shape.is_error, likely=False) as (then, otherwise):
+                        with then:
+                            c.builder.store(cgutils.true_bit, is_error_ptr)
+                            c.builder.store(fail_obj, ret_ptr)
+                        with otherwise:
+                            fill_value = _unbox_native_field(typ.fill_value_type, obj, "fill_value", c)
+                            with c.builder.if_else(fill_value.is_error, likely=False) as (then, otherwise):
+                                with then:
+                                    c.builder.store(cgutils.true_bit, is_error_ptr)
+                                    c.builder.store(fail_obj, ret_ptr)
+                                with otherwise:
+                                    coo = cgutils.create_struct_proxy(typ)(c.context, c.builder)
+                                    coo.coords = coords.value
+                                    coo.data = data.value
+                                    coo.shape = shape.value
+                                    coo.fill_value = fill_value.value
+                                    c.builder.store(cgutils.false_bit, is_error_ptr)
+                                    c.builder.store(coo._getvalue(), ret_ptr)
+    return NativeValue(c.builder.load(ret_ptr), is_error=c.builder.load(is_error_ptr))
 
 
 @box(COOType)
-def box_COO(typ: COOType, val: NativeValue, c) -> COO:
+def box_COO(typ: COOType, val: "some LLVM thing", c) -> COO:
+    ret_ptr = cgutils.alloca_once(c.builder, c.pyapi.pyobj)
+    fail_obj = c.pyapi.get_null_object()
+
+    # there's no way to early return here - we have no choice but to nest like crazy...
+
     coo = cgutils.create_struct_proxy(typ)(c.context, c.builder, value=val)
+
     data_obj = c.box(typ.data_type, coo.data)
-    coords_obj = c.box(typ.coords_type, coo.coords)
-    shape_obj = c.box(typ.shape_type, coo.shape)
-    fill_value_obj = c.box(typ.fill_value_type, coo.fill_value)
-    class_obj = c.pyapi.unserialize(c.pyapi.serialize_object(COO))
-    args = c.pyapi.tuple_pack([coords_obj, data_obj, shape_obj])
-    kwargs = c.pyapi.dict_pack([("fill_value", fill_value_obj)])
-    res = c.pyapi.call(class_obj, args, kwargs)
-    c.pyapi.decref(class_obj)
-    c.pyapi.decref(data_obj)
-    c.pyapi.decref(coords_obj)
-    c.pyapi.decref(shape_obj)
-    c.pyapi.decref(fill_value_obj)
-    return res
+    with c.builder.if_else(cgutils.is_null(c.builder, data_obj), likely=False) as (then, otherwise):
+        with then:
+            c.builder.store(fail_obj, ret_ptr)
+        with otherwise:
+
+            coords_obj = c.box(typ.coords_type, coo.coords)
+            with c.builder.if_else(cgutils.is_null(c.builder, coords_obj), likely=False) as (then, otherwise):
+                with then:
+                    c.pyapi.decref(data_obj)
+                    c.builder.store(fail_obj, ret_ptr)
+                with otherwise:
+
+                    shape_obj = c.box(typ.shape_type, coo.shape)
+                    with c.builder.if_else(cgutils.is_null(c.builder, shape_obj), likely=False) as (then, otherwise):
+                        with then:
+                            c.pyapi.decref(coords_obj)
+                            c.pyapi.decref(data_obj)
+                            c.builder.store(fail_obj, ret_ptr)
+                        with otherwise:
+
+                            fill_value_obj = c.box(typ.fill_value_type, coo.fill_value)
+                            with c.builder.if_else(cgutils.is_null(c.builder, fill_value_obj), likely=False) as (then, otherwise):
+                                with then:
+                                    c.pyapi.decref(shape_obj)
+                                    c.pyapi.decref(coords_obj)
+                                    c.pyapi.decref(data_obj)
+                                    c.builder.store(fail_obj, ret_ptr)
+                                with otherwise:
+
+                                    class_obj = c.pyapi.unserialize(c.pyapi.serialize_object(COO))
+                                    with c.builder.if_else(cgutils.is_null(c.builder, class_obj), likely=False) as (then, otherwise):
+                                        with then:
+                                            c.pyapi.decref(shape_obj)
+                                            c.pyapi.decref(coords_obj)
+                                            c.pyapi.decref(data_obj)
+                                            c.pyapi.decref(fill_value_obj)
+                                            c.builder.store(fail_obj, ret_ptr)
+                                        with otherwise:
+                                            args = c.pyapi.tuple_pack([coords_obj, data_obj, shape_obj])
+                                            c.pyapi.decref(shape_obj)
+                                            c.pyapi.decref(coords_obj)
+                                            c.pyapi.decref(data_obj)
+                                            with c.builder.if_else(cgutils.is_null(c.builder, args), likely=False) as (then, otherwise):
+                                                with then:
+                                                    c.pyapi.decref(fill_value_obj)
+                                                    c.pyapi.decref(class_obj)
+                                                    c.builder.store(fail_obj, ret_ptr)
+                                                with otherwise:
+
+                                                    kwargs = c.pyapi.dict_pack([("fill_value", fill_value_obj)])
+                                                    c.pyapi.decref(fill_value_obj)
+                                                    with c.builder.if_else(cgutils.is_null(c.builder, kwargs), likely=False) as (then, otherwise):
+                                                        with then:
+                                                            c.pyapi.decref(class_obj)
+                                                            c.builder.store(fail_obj, ret_ptr)
+                                                        with otherwise:
+                                                            c.builder.store(c.pyapi.call(class_obj, args, kwargs), ret_ptr)
+    return c.builder.load(ret_ptr)
 
 
 make_attribute_wrapper(COOType, "data", "data")

--- a/sparse/_coo/numba_extension.py
+++ b/sparse/_coo/numba_extension.py
@@ -1,0 +1,165 @@
+"""
+Numba support for COO objects.
+
+For now, this just supports attribute access
+"""
+import numpy as np
+import numba
+from numba.extending import (
+    models,
+    register_model,
+    box,
+    unbox,
+    NativeValue,
+    make_attribute_wrapper,
+    type_callable,
+    lower_builtin,
+)
+from numba.targets.imputils import impl_ret_borrowed, lower_constant
+from numba.typing.typeof import typeof_impl
+from numba import cgutils, types
+from sparse._utils import _zero_of_dtype
+
+from . import COO
+
+__all__ = ["COOType"]
+
+
+class COOType(types.Type):
+    def __init__(self, data_dtype: np.dtype, coords_dtype: np.dtype, ndim: int):
+        assert isinstance(data_dtype, np.dtype)
+        assert isinstance(coords_dtype, np.dtype)
+        self.data_dtype = data_dtype
+        self.coords_dtype = coords_dtype
+        self.ndim = ndim
+        super().__init__(
+            name="COOType[{!r}, {!r}, {!r}]".format(
+                numba.from_dtype(data_dtype), numba.from_dtype(coords_dtype), ndim
+            )
+        )
+
+    @property
+    def key(self):
+        return self.data_dtype, self.coords_dtype, self.ndim
+
+    @property
+    def data_type(self):
+        return numba.from_dtype(self.data_dtype)[:]
+
+    @property
+    def coords_type(self):
+        return numba.from_dtype(self.coords_dtype)[:, :]
+
+    @property
+    def shape_type(self):
+        return types.UniTuple(types.int64, self.ndim)
+
+    @property
+    def fill_value_type(self):
+        return numba.from_dtype(self.data_dtype)
+
+
+@typeof_impl.register(COO)
+def _typeof_COO(val: COO, c) -> COOType:
+    return COOType(
+        data_dtype=val.data.dtype, coords_dtype=val.coords.dtype, ndim=val.ndim
+    )
+
+
+@register_model(COOType)
+class COOModel(models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [
+            ("data", fe_type.data_type),
+            ("coords", fe_type.coords_type),
+            ("shape", fe_type.shape_type),
+            ("fill_value", fe_type.fill_value_type),
+        ]
+        models.StructModel.__init__(self, dmm, fe_type, members)
+
+
+@type_callable(COO)
+def type_COO(context):
+    # TODO: accept a fill_value kwarg
+    def typer(coords, data, shape):
+        return COOType(
+            coords_dtype=numba.numpy_support.as_dtype(coords.dtype),
+            data_dtype=numba.numpy_support.as_dtype(data.dtype),
+            ndim=len(shape),
+        )
+
+    return typer
+
+
+@lower_builtin(COO, types.Any, types.Any, types.Any)
+def impl_COO(context, builder, sig, args):
+    typ = sig.return_type
+    coords, data, shape = args
+    coo = cgutils.create_struct_proxy(typ)(context, builder)
+    coo.coords = coords
+    coo.data = data
+    coo.shape = shape
+    coo.fill_value = context.get_constant_generic(
+        builder, typ.fill_value_type, _zero_of_dtype(typ.data_dtype)
+    )
+    return impl_ret_borrowed(context, builder, sig.return_type, coo._getvalue())
+
+
+@lower_constant(COOType)
+def lower_constant_COO(context, builder, typ, pyval):
+    coords = context.get_constant_generic(builder, typ.coords_type, pyval.coords)
+    data = context.get_constant_generic(builder, typ.data_type, pyval.data)
+    shape = context.get_constant_generic(builder, typ.shape_type, pyval.shape)
+    fill_value = context.get_constant_generic(
+        builder, typ.fill_value_type, pyval.fill_value
+    )
+    return impl_ret_borrowed(
+        context,
+        builder,
+        typ,
+        cgutils.pack_struct(builder, (data, coords, shape, fill_value)),
+    )
+
+
+@unbox(COOType)
+def unbox_COO(typ: COOType, obj: COO, c) -> NativeValue:
+    data = c.pyapi.object_getattr_string(obj, "data")
+    coords = c.pyapi.object_getattr_string(obj, "coords")
+    shape = c.pyapi.object_getattr_string(obj, "shape")
+    fill_value = c.pyapi.object_getattr_string(obj, "fill_value")
+    coo = cgutils.create_struct_proxy(typ)(c.context, c.builder)
+    coo.coords = c.unbox(typ.coords_type, coords).value
+    coo.data = c.unbox(typ.data_type, data).value
+    coo.shape = c.unbox(typ.shape_type, shape).value
+    coo.fill_value = c.unbox(typ.fill_value_type, fill_value).value
+    c.pyapi.decref(data)
+    c.pyapi.decref(coords)
+    c.pyapi.decref(shape)
+    c.pyapi.decref(fill_value)
+    is_error = cgutils.is_not_null(c.builder, c.pyapi.err_occurred())
+    return NativeValue(coo._getvalue(), is_error=is_error)
+
+
+@box(COOType)
+def box_COO(typ: COOType, val: NativeValue, c) -> COO:
+    coo = cgutils.create_struct_proxy(typ)(c.context, c.builder, value=val)
+    data_obj = c.box(typ.data_type, coo.data)
+    coords_obj = c.box(typ.coords_type, coo.coords)
+    shape_obj = c.box(typ.shape_type, coo.shape)
+    fill_value_obj = c.box(typ.fill_value_type, coo.fill_value)
+    class_obj = c.pyapi.unserialize(c.pyapi.serialize_object(COO))
+    args = c.pyapi.tuple_pack([coords_obj, data_obj, shape_obj])
+    kwargs = c.pyapi.dict_pack([("fill_value", fill_value_obj)])
+    res = c.pyapi.call(class_obj, args, kwargs)
+    c.pyapi.decref(class_obj)
+    c.pyapi.decref(data_obj)
+    c.pyapi.decref(coords_obj)
+    c.pyapi.decref(shape_obj)
+    c.pyapi.decref(fill_value_obj)
+    return res
+
+
+make_attribute_wrapper(COOType, "data", "data")
+make_attribute_wrapper(COOType, "coords", "coords")
+make_attribute_wrapper(COOType, "shape", "shape")
+make_attribute_wrapper(COOType, "fill_value", "fill_value")

--- a/sparse/_numba_extension.py
+++ b/sparse/_numba_extension.py
@@ -1,0 +1,6 @@
+def _init_extension():
+    """
+    Load extensions when numba is loaded.
+    This name must match the one in setup.py
+    """
+    import sparse._coo.numba_extension

--- a/sparse/tests/test_coo_numba.py
+++ b/sparse/tests/test_coo_numba.py
@@ -1,0 +1,69 @@
+import pytest
+import numba
+
+import sparse
+import numpy as np
+
+
+@numba.njit
+def identity(x):
+    """ Pass an object through numba and back """
+    return x
+
+
+def identity_constant(x):
+    @numba.njit
+    def get_it():
+        """ Pass an object through numba and back as a constant """
+        return x
+
+    return get_it()
+
+
+def assert_coo_equal(c1, c2):
+    assert c1.shape == c2.shape
+    assert c1 == c2
+    assert c1.data.dtype == c2.data.dtype
+    assert c1.fill_value == c2.fill_value
+
+
+def assert_coo_same_memory(c1, c2):
+    assert_coo_equal(c1, c2)
+    assert c1.coords.data == c2.coords.data
+    assert c1.data.data == c2.data.data
+
+
+class TestBasic:
+    """ Test very simple construction and field access """
+
+    def test_roundtrip(self):
+        c1 = sparse.COO(np.eye(3), fill_value=1)
+        c2 = identity(c1)
+        assert type(c1) is type(c2)
+        assert_coo_same_memory(c1, c2)
+
+    def test_roundtrip_constant(self):
+        c1 = sparse.COO(np.eye(3), fill_value=1)
+        c2 = identity_constant(c1)
+        # constants are always copies
+        assert_coo_equal(c1, c2)
+
+    def test_unpack_attrs(self):
+        @numba.njit
+        def unpack(c):
+            return c.coords, c.data, c.shape, c.fill_value
+
+        c1 = sparse.COO(np.eye(3), fill_value=1)
+        coords, data, shape, fill_value = unpack(c1)
+        c2 = sparse.COO(coords, data, shape, fill_value=fill_value)
+        assert_coo_same_memory(c1, c2)
+
+    def test_repack_attrs(self):
+        @numba.njit
+        def pack(coords, data, shape):
+            return sparse.COO(coords, data, shape)
+
+        # repacking fill_value isn't possible yet
+        c1 = sparse.COO(np.eye(3))
+        c2 = pack(c1.coords, c1.data, c1.shape)
+        assert_coo_same_memory(c1, c2)


### PR DESCRIPTION
Over in pygae/clifford, we're finding we want to be able to write optimized loops using `arr.coords` and `arr.data`.

This aims to be the minimum amount needed to make that work.

~~Marking as draft since this has no tests~~

cc @stuartarchibald, @luk-f-a