### PR TITLE
Fix setting into numpy slice

### DIFF
--- a/sparse/_sparse_array.py
+++ b/sparse/_sparse_array.py
@@ -215,7 +215,7 @@ class SparseArray:
         True
         """
 
-    def __array__(self, **kwargs):
+    def __array__(self, *args, **kwargs):
         from ._settings import AUTO_DENSIFY
 
         if not AUTO_DENSIFY:
@@ -224,7 +224,7 @@ class SparseArray:
                 "To manually densify, use the todense method."
             )
 
-        return np.asarray(self.todense(), **kwargs)
+        return np.asarray(self.todense(), *args, **kwargs)
 
     def __array_function__(self, func, types, args, kwargs):
         import sparse as module

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -2121,13 +2121,20 @@ def test_setting_into_numpy_slice():
     assert_eq(actual, expected)
 
 
-def test_failed_densification():
+
+def test_successful_densification():
     s = sparse.random((3, 4, 5), density=0.5)
     with auto_densify():
         x = np.array(s)
 
     assert isinstance(x, np.ndarray)
     assert_eq(s, x)
+
+
+def test_failed_densification():
+    s = sparse.random((3, 4, 5), density=0.5)
+    with pytest.raises(RuntimeError):
+        np.array(s)
 
 
 def test_warn_on_too_dense():

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -2109,7 +2109,7 @@ def auto_densify():
 def test_setting_into_numpy_slice():
     actual = np.zeros((5, 5))
     s = sparse.COO(data=[1, 1], coords=(2, 4), shape=(5,))
-    # This calls b.__array__(dtype('float64')) which means that __array__
+    # This calls s.__array__(dtype('float64')) which means that __array__
     # must accept a positional argument. If not this will raise, of course,
     # TypeError: __array__() takes 1 positional argument but 2 were given
     with auto_densify():

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -2120,6 +2120,9 @@ def test_setting_into_numpy_slice():
     expected[:, 0] = s.todense()
     assert_eq(actual, expected)
 
+    # Without densification, setting is unsupported.
+    with pytest.raises(RuntimeError):
+        actual[:, 0] = s
 
 
 def test_successful_densification():

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -2106,6 +2106,21 @@ def auto_densify():
     reload(sparse._settings)
 
 
+def test_setting_into_numpy_slice():
+    actual = np.zeros((5, 5))
+    s = sparse.COO(data=[1, 1], coords=(2, 4), shape=(5,))
+    # This calls b.__array__(dtype('float64')) which means that __array__
+    # must accept a positional argument. If not this will raise, of course,
+    # TypeError: __array__() takes 1 positional argument but 2 were given
+    with auto_densify():
+        actual[:, 0] = s
+
+    # Might as well check the content of the result as well.
+    expected = np.zeros((5, 5))
+    expected[:, 0] = s.todense()
+    assert_eq(actual, expected)
+
+
 def test_failed_densification():
     s = sparse.random((3, 4, 5), density=0.5)
     with auto_densify():


### PR DESCRIPTION
Includes test that exercises the bug. Illustration:

```
In [1]: import numpy                                                                                                                                                                          

In [2]: import sparse                                                                                                                                                                         

In [3]: a = numpy.zeros((5, 5))                                                                                                                                                               

In [4]: b = sparse.COO(data=[1, 1], coords=(2, 4), shape=(5,))                                                                                                                                

In [5]: a[:, 0] = b                                                                                                                                                                           
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-ebf8ebabc230> in <module>
----> 1 a[:, 0] = b

TypeError: __array__() takes 1 positional argument but 2 were given

In [6]: %env SPARSE_AUTO_DENSIFY                                                                                                                                                              
Out[6]: '1'
```

As shown, `SPARSE_AUTO_DENSIFY` was set to `1`. The same error occurs with `SPARSE_AUTO_DENSIFY` unset. It _should_ raise `RuntimeError: Cannot convert a sparse array....` instead.

While I was here, I noticed that the test `test_failed_densification` seemed to be actually testing _successful_ densification. I took the liberty of renaming it and adding a second test that actually tests for failure.