### PR TITLE
Implement asarray.

### DIFF
--- a/sparse/_common.py
+++ b/sparse/_common.py
@@ -438,3 +438,21 @@ def outer(a, b, out=None):
            [0, 3, 6, 9]])
     """
     return np.multiply.outer(a, b, out=out)
+
+
+def asnumpy(a, dtype=None, order=None):
+    """Returns a dense numpy array from an arbitrary source array.
+
+    Args:
+        a: Arbitrary object that can be converted to :class:`numpy.ndarray`.
+        order ({'C', 'F', 'A'}): The desired memory layout of the output
+            array. When ``order`` is 'A', it uses 'F' if ``a`` is
+            fortran-contiguous and 'C' otherwise.
+    Returns:
+        numpy.ndarray: Converted array on the host memory.
+    """
+    from ._sparse_array import SparseArray
+
+    if isinstance(a, SparseArray):
+        a = a.todense()
+    return np.array(a, dtype=dtype, copy=False, order=order)

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -2226,3 +2226,14 @@ def test_flatten(in_shape):
     e = x.flatten()
 
     assert_eq(e, a)
+
+
+def test_asnumpy():
+    s = sparse.COO(data=[1], coords=[2], shape=(5,))
+    assert_eq(sparse.asnumpy(s), s.todense())
+    assert_eq(
+        sparse.asnumpy(s, dtype=np.float64), np.asarray(s.todense(), dtype=np.float64)
+    )
+    a = np.array([1, 2, 3])
+    # Array passes through with no copying.
+    assert sparse.asnumpy(a) is a


### PR DESCRIPTION
This is modeled on ``cupy.asarray``. Future work may use numpy protocols
to let duck arrays of sparse arrays pass through properly, such as a
dask array of sparse arrays. See #319 and issues linked therein for
discussion. Closes #319 