### PR TITLE
Respect `copy=False` in `astype`

### DIFF
--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -2186,6 +2186,9 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         :obj:`COO.elemwise`: Apply an arbitrary element-wise function to one or two
             arguments.
         """
+        # this matches numpy's behavior
+        if self.dtype == dtype and copy == False:
+            return self
         return self.__array_ufunc__(
             np.ndarray.astype, "__call__", self, dtype=dtype, copy=copy
         )

--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -2187,7 +2187,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
             arguments.
         """
         # this matches numpy's behavior
-        if self.dtype == dtype and copy == False:
+        if self.dtype == dtype and not copy:
             return self
         return self.__array_ufunc__(
             np.ndarray.astype, "__call__", self, dtype=dtype, copy=copy


### PR DESCRIPTION
Previously this would make a copy anyway.