### PR TITLE
added method swapaxes to COO

### DIFF
--- a/docs/generated/sparse.COO.rst
+++ b/docs/generated/sparse.COO.rst
@@ -76,6 +76,7 @@ COO
       COO.reshape
       COO.resize
       COO.transpose
+      COO.swapaxes
       COO.nonzero
 
    .. rubric:: Utility functions

--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -1551,7 +1551,9 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         <COO: shape=(4, 3, 2), dtype=float64, nnz=24, fill_value=0.0>
         """
         # Normalize all axis1, axis2 to positive values
-        axis1, axis2 = normalize_axis((axis1, axis2), self.ndim)  # checks if axis1,2 are in range + raises ValueError
+        axis1, axis2 = normalize_axis(
+            (axis1, axis2), self.ndim
+        )  # checks if axis1,2 are in range + raises ValueError
         axes = list(range(self.ndim))
         axes[axis1], axes[axis2] = axes[axis2], axes[axis1]
         return self.transpose(axes)

--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -1529,6 +1529,33 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         """
         return self.transpose(tuple(range(self.ndim))[::-1])
 
+    def swapaxes(self, axis1, axis2):
+        """ Returns array that has axes axis1 and axis2 swapped.
+
+        Parameters
+        ----------
+        axis1 : int
+            first axis to swap
+        axis2: int
+            second axis to swap
+
+        Returns
+        -------
+        COO
+            The new array with the axes axis1 and axis2 swapped.
+
+        Examples
+        --------
+        >>> x = COO.from_numpy(np.ones((2, 3, 4)))
+        >>> x.swapaxes(0, 2)
+        <COO: shape=(4, 3, 2), dtype=float64, nnz=24, fill_value=0.0>
+        """
+        # Normalize all axis1, axis2 to positive values
+        axis1, axis2 = normalize_axis((axis1, axis2), self.ndim)  # checks if axis1,2 are in range + raises ValueError
+        axes = list(range(self.ndim))
+        axes[axis1], axes[axis2] = axes[axis2], axes[axis1]
+        return self.transpose(axes)
+
     @property
     def real(self):
         """The real part of the array.

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -214,6 +214,25 @@ def test_transpose_error(axis):
         x.transpose(axis)
 
 
+@pytest.mark.parametrize("axis1", [-3, -2, -1, 0, 1, 2])
+@pytest.mark.parametrize("axis2", [-3, -2, -1, 0, 1, 2])
+def test_swapaxes(axis1, axis2):
+    x = sparse.random((2, 3, 4), density=0.25)
+    y = x.todense()
+    xx = x.swapaxes(axis1, axis2)
+    yy = y.swapaxes(axis1, axis2)
+    assert_eq(xx, yy)
+
+
+@pytest.mark.parametrize("axis1", [-4, 3])
+@pytest.mark.parametrize("axis2", [-4, 3, 0])
+def test_swapaxes_error(axis1, axis2):
+    x = sparse.random((2, 3, 4), density=0.25)
+
+    with pytest.raises(ValueError):
+        x.swapaxes(axis1, axis2)
+
+
 @pytest.mark.parametrize(
     "a,b",
     [


### PR DESCRIPTION
Hello,

I wanted to run some code I wrote for numpy arrays with COO arrays from this library, but unfortunately the np.swapaxes method was used. As this method did not exist for sparse arrays I quickly added it to the COO class. I also added a quick test to make sure everything works.

Best regards,
Marvin