### PR TITLE
Choose sparse/dense type when doing tensordot

### DIFF
--- a/benchmarks/benchmark_coo.py
+++ b/benchmarks/benchmark_coo.py
@@ -3,6 +3,18 @@ import numpy as np
 import sparse
 
 
+class MatrixMultiplySuite:
+    def setup(self):
+        np.random.seed(0)
+        self.x = sparse.random((100, 100), density=0.01)
+        self.y = sparse.random((100, 100), density=0.01)
+
+        self.x @ self.y  # Numba compilation
+
+    def time_matmul(self):
+        self.x @ self.y
+
+
 class ElemwiseSuite:
     def setup(self):
         np.random.seed(0)

--- a/benchmarks/benchmark_tensordot.py
+++ b/benchmarks/benchmark_tensordot.py
@@ -6,7 +6,7 @@ class TensordotSuite:
     def setup(self):
         np.random.seed(0)
         self.n = np.random.random((100, 100))
-        self.s = sparse.random((100, 100, 100, 100), density=0.01)
+        self.s = sparse.random((100, 100, 100, 100), density=0.001)
 
     def time_dense(self):
         sparse.tensordot(self.n, self.s, axes=([0, 1], [0, 2]))

--- a/benchmarks/benchmark_tensordot.py
+++ b/benchmarks/benchmark_tensordot.py
@@ -32,7 +32,9 @@ class TensordotSuiteSparseSparse:
         self.s2 = sparse.random((100, 100, 100, 100), density=0.01)
 
     def time_dense(self):
-        sparse.tensordot(self.s1, self.s2, axes=([0, 1], [0, 2]), return_type=np.ndarray)
+        sparse.tensordot(
+            self.s1, self.s2, axes=([0, 1], [0, 2]), return_type=np.ndarray
+        )
 
     def time_sparse(self):
         sparse.tensordot(self.s1, self.s2, axes=([0, 1], [0, 2]))

--- a/benchmarks/benchmark_tensordot.py
+++ b/benchmarks/benchmark_tensordot.py
@@ -3,10 +3,13 @@ import sparse
 
 
 class TensordotSuite:
+    """
+    Performance comparison for returntype="sparse".
+    """
     def setup(self):
         np.random.seed(0)
         self.n = np.random.random((100, 100))
-        self.s = sparse.random((100, 100, 100, 100), density=0.001)
+        self.s = sparse.random((100, 100, 100, 100), density=0.01)
 
     def time_dense(self):
         sparse.tensordot(self.n, self.s, axes=([0, 1], [0, 2]))

--- a/benchmarks/benchmark_tensordot.py
+++ b/benchmarks/benchmark_tensordot.py
@@ -15,4 +15,4 @@ class TensordotSuite:
         sparse.tensordot(self.n, self.s, axes=([0, 1], [0, 2]))
 
     def time_sparse(self):
-        sparse.tensordot(self.n, self.s, axes=([0, 1], [0, 2]), returntype="sparse")
+        sparse.tensordot(self.n, self.s, axes=([0, 1], [0, 2]), return_type=sparse.COO)

--- a/benchmarks/benchmark_tensordot.py
+++ b/benchmarks/benchmark_tensordot.py
@@ -1,0 +1,15 @@
+import numpy as np
+import sparse
+
+
+class TensordotSuite:
+    def setup(self):
+        np.random.seed(0)
+        self.n = np.random.random((100, 100))
+        self.s = sparse.random((100, 100, 100, 100), density=0.01)
+
+    def time_dense(self):
+        sparse.tensordot(self.n, self.s, axes=([0, 1], [0, 2]))
+
+    def time_sparse(self):
+        sparse.tensordot(self.n, self.s, axes=([0, 1], [0, 2]), returntype="sparse")

--- a/benchmarks/benchmark_tensordot.py
+++ b/benchmarks/benchmark_tensordot.py
@@ -2,9 +2,10 @@ import numpy as np
 import sparse
 
 
-class TensordotSuite:
+class TensordotSuiteDenseSparse:
     """
-    Performance comparison for returntype="sparse".
+    Performance comparison for returntype=COO vs returntype=np.ndarray.
+    tensordot(np.ndarray, COO)
     """
 
     def setup(self):
@@ -17,3 +18,39 @@ class TensordotSuite:
 
     def time_sparse(self):
         sparse.tensordot(self.n, self.s, axes=([0, 1], [0, 2]), return_type=sparse.COO)
+
+
+class TensordotSuiteSparseSparse:
+    """
+    Performance comparison for returntype=COO vs returntype=np.ndarray.
+    tensordot(COO, COO)
+    """
+
+    def setup(self):
+        np.random.seed(0)
+        self.s1 = sparse.random((100, 100), density=0.01)
+        self.s2 = sparse.random((100, 100, 100, 100), density=0.01)
+
+    def time_dense(self):
+        sparse.tensordot(self.s1, self.s2, axes=([0, 1], [0, 2]), return_type=np.ndarray)
+
+    def time_sparse(self):
+        sparse.tensordot(self.s1, self.s2, axes=([0, 1], [0, 2]))
+
+
+class TensordotSuiteSparseDense:
+    """
+    Performance comparison for returntype=COO vs returntype=np.ndarray.
+    tensordot(COO, np.ndarray)
+    """
+
+    def setup(self):
+        np.random.seed(0)
+        self.s = sparse.random((100, 100, 100, 100), density=0.01)
+        self.n = np.random.random((100, 100))
+
+    def time_dense(self):
+        sparse.tensordot(self.s, self.n, axes=([0, 1], [0, 1]))
+
+    def time_sparse(self):
+        sparse.tensordot(self.s, self.n, axes=([0, 1], [0, 1]), return_type=sparse.COO)

--- a/benchmarks/benchmark_tensordot.py
+++ b/benchmarks/benchmark_tensordot.py
@@ -6,6 +6,7 @@ class TensordotSuite:
     """
     Performance comparison for returntype="sparse".
     """
+
     def setup(self):
         np.random.seed(0)
         self.n = np.random.random((100, 100))

--- a/sparse/_coo/common.py
+++ b/sparse/_coo/common.py
@@ -1166,44 +1166,45 @@ def _dot_coo_coo_type(dt1, dt2):
         coords_out = []
         data_out = []
         didx1 = 0
+        data1_end = len(data1)
+        data2_end = len(data2)
 
-        while didx1 < len(data1):
+        while didx1 < data1_end:
             oidx1 = coords1[0, didx1]
             didx2 = 0
             didx1_curr = didx1
 
             while (
-                didx2 < len(data2) and didx1 < len(data1) and coords1[0, didx1] == oidx1
+                didx2 < data2_end and didx1 < data1_end and coords1[0, didx1] == oidx1
             ):
                 oidx2 = coords2[0, didx2]
                 data_curr = 0
 
                 while (
-                    didx2 < len(data2)
-                    and didx1 < len(data1)
+                    didx2 < data2_end
+                    and didx1 < data1_end
                     and coords2[0, didx2] == oidx2
                     and coords1[0, didx1] == oidx1
                 ):
-                    if coords1[1, didx1] < coords2[1, didx2]:
-                        didx1 += 1
-                    elif coords1[1, didx1] > coords2[1, didx2]:
-                        didx2 += 1
-                    else:
+                    c1 = coords1[1, didx1]
+                    c2 = coords2[1, didx2]
+                    k = min(c1, c2)
+                    if c1 == k and c2 == k:
                         data_curr += data1[didx1] * data2[didx2]
-                        didx1 += 1
-                        didx2 += 1
+                    didx1 += c1 == k
+                    didx2 += c2 == k
 
-                while didx2 < len(data2) and coords2[0, didx2] == oidx2:
+                while didx2 < data2_end and coords2[0, didx2] == oidx2:
                     didx2 += 1
 
-                if didx2 < len(data2):
+                if didx2 < data2_end:
                     didx1 = didx1_curr
 
                 if data_curr != 0:
                     coords_out.append((oidx1, oidx2))
                     data_out.append(data_curr)
 
-            while didx1 < len(data1) and coords1[0, didx1] == oidx1:
+            while didx1 < data1_end and coords1[0, didx1] == oidx1:
                 didx1 += 1
 
         if len(data_out) == 0:

--- a/sparse/_coo/common.py
+++ b/sparse/_coo/common.py
@@ -74,6 +74,9 @@ def tensordot(a, b, axes=2, returntype="auto"):
         The arrays to perform the :code:`tensordot` operation on.
     axes : tuple[Union[int, tuple[int], Union[int, tuple[int]], optional
         The axes to match when performing the sum.
+    returntype : {"auto", "dense", "sparse"}, optional
+        Type of returned array.
+
 
     Returns
     -------
@@ -295,6 +298,7 @@ def _dot(a, b, returntype="auto"):
 
     out_shape = (a.shape[0], b.shape[1])
     if isinstance(a, COO) and isinstance(b, COO):
+        # todo: if returntype == "dense": ...
         b = b.T
         coords, data = _dot_coo_coo_type(a.dtype, b.dtype)(
             a.coords, a.data, b.coords, b.data
@@ -303,6 +307,7 @@ def _dot(a, b, returntype="auto"):
         return COO(coords, data, shape=out_shape, has_duplicates=False, sorted=True)
 
     if isinstance(a, COO) and isinstance(b, np.ndarray):
+        # todo: if returntype == "sparse": ...
         b = b.view(type=np.ndarray).T
         return _dot_coo_ndarray_type(a.dtype, b.dtype)(a.coords, a.data, b, out_shape)
 
@@ -1324,6 +1329,7 @@ def _dot_ndarray_coo_type_sparse(dt1, dt2):
                 oidx2 = coords2[0, didx2]
                 out_coords.append([oidx1, oidx2])
                 out_data.append(array1[oidx1, coords2[1, didx2]] * data2[didx2])
+                # attention: data can be 0.0
 
         return out_coords, out_data, dtr
 

--- a/sparse/_coo/common.py
+++ b/sparse/_coo/common.py
@@ -1320,7 +1320,7 @@ def _dot_coo_ndarray_type_sparse(dt1, dt2):
             while oidx2 < out_shape[1]:
                 cur_didx1 = didx1
                 data_curr = 0
-                while coords1[0, cur_didx1] == current_row:
+                while cur_didx1 < len(data1) and coords1[0, cur_didx1] == current_row:
                     data_curr += data1[cur_didx1] * array2[oidx2, coords1[1, cur_didx1]]
                     cur_didx1 += 1
                 if data_curr != 0:

--- a/sparse/_coo/common.py
+++ b/sparse/_coo/common.py
@@ -315,7 +315,7 @@ def _dot(a, b, returntype="auto"):
             )
             coords = np.array(coords).T
             data = np.array(data, dtype=dtype)
-            return COO(coords, data, shape=out_shape)
+            return COO(coords, data, shape=out_shape, prune=True)
         return _dot_ndarray_coo_type(a.dtype, b.dtype)(a, b.coords, b.data, out_shape)
 
 
@@ -1322,10 +1322,8 @@ def _dot_ndarray_coo_type_sparse(dt1, dt2):
         for oidx1 in range(out_shape[0]):
             for didx2 in range(len(data2)):
                 oidx2 = coords2[0, didx2]
-                val = array1[oidx1, coords2[1, didx2]]
-                if val != 0.0:
-                    out_coords.append([oidx1, oidx2])
-                    out_data.append(val * data2[didx2])
+                out_coords.append([oidx1, oidx2])
+                out_data.append(array1[oidx1, coords2[1, didx2]] * data2[didx2])
 
         return out_coords, out_data, dtr
 

--- a/sparse/_coo/common.py
+++ b/sparse/_coo/common.py
@@ -64,7 +64,7 @@ def linear_loc(coords, shape):
         return np.ravel_multi_index(coords, shape)
 
 
-def tensordot(a, b, axes=2):
+def tensordot(a, b, axes=2, returntype="auto"):
     """
     Perform the equivalent of :obj:`numpy.tensordot`.
 
@@ -168,7 +168,7 @@ def tensordot(a, b, axes=2):
 
     at = a.transpose(newaxes_a).reshape(newshape_a)
     bt = b.transpose(newaxes_b).reshape(newshape_b)
-    res = _dot(at, bt)
+    res = _dot(at, bt, returntype)
     return res.reshape(olda + oldb)
 
 
@@ -290,7 +290,7 @@ def dot(a, b):
     return tensordot(a, b, axes=(a_axis, b_axis))
 
 
-def _dot(a, b):
+def _dot(a, b, returntype="auto"):
     from .core import COO
 
     out_shape = (a.shape[0], b.shape[1])
@@ -309,6 +309,13 @@ def _dot(a, b):
     if isinstance(a, np.ndarray) and isinstance(b, COO):
         b = b.T
         a = a.view(type=np.ndarray)
+        if returntype == "sparse":
+            coords, data, dtype = _dot_ndarray_coo_type_sparse(a.dtype, b.dtype)(
+                a, b.coords, b.data, out_shape
+            )
+            coords = np.array(coords).T
+            data = np.array(data, dtype=dtype)
+            return COO(coords, data, shape=out_shape)
         return _dot_ndarray_coo_type(a.dtype, b.dtype)(a, b.coords, b.data, out_shape)
 
 
@@ -1284,6 +1291,43 @@ def _dot_ndarray_coo_type(dt1, dt2):
                 out[oidx1, oidx2] += array1[oidx1, coords2[1, didx2]] * data2[didx2]
 
         return out
+
+    return _dot_ndarray_coo
+
+
+@_memoize_dtype
+def _dot_ndarray_coo_type_sparse(dt1, dt2):
+    dtr = np.result_type(dt1, dt2)
+
+    @numba.jit(nopython=True, nogil=True)
+    def _dot_ndarray_coo(array1, coords2, data2, out_shape):  # pragma: no cover
+        """
+        Utility function taking in two one ``ndarray`` and one ``COO`` and
+        calculating a "sense" of their dot product. Acually computes ``x1 @ s2.T``.
+
+        Parameters
+        ----------
+        array1 : np.ndarray
+            The input array ``x1``.
+
+        data2, coords2 : np.ndarray
+            The data and coordinates of ``s2``.
+
+        out_shape : Tuple[int]
+            The output shape.
+        """
+        out_data = []
+        out_coords = []
+
+        for oidx1 in range(out_shape[0]):
+            for didx2 in range(len(data2)):
+                oidx2 = coords2[0, didx2]
+                val = array1[oidx1, coords2[1, didx2]]
+                if val != 0.0:
+                    out_coords.append([oidx1, oidx2])
+                    out_data.append(val * data2[didx2])
+
+        return out_coords, out_data, dtr
 
     return _dot_ndarray_coo
 

--- a/sparse/_coo/common.py
+++ b/sparse/_coo/common.py
@@ -64,7 +64,7 @@ def linear_loc(coords, shape):
         return np.ravel_multi_index(coords, shape)
 
 
-def tensordot(a, b, axes=2, return_type=None):
+def tensordot(a, b, axes=2, *, return_type=None):
     """
     Perform the equivalent of :obj:`numpy.tensordot`.
 

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -352,9 +352,7 @@ def test_tensordot(a_shape, b_shape, axes):
 
     # assert isinstance(sparse.tensordot(a, sb, axes), COO)
 
-    assert_eq(
-        np.tensordot(a, b, axes), sparse.tensordot(a, sb, axes, return_type=COO)
-    )
+    assert_eq(np.tensordot(a, b, axes), sparse.tensordot(a, sb, axes, return_type=COO))
 
     assert isinstance(sparse.tensordot(a, sb, axes, return_type=COO), COO)
 

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -356,6 +356,8 @@ def test_tensordot(a_shape, b_shape, axes):
         np.tensordot(a, b, axes), sparse.tensordot(a, sb, axes, returntype="sparse")
     )
 
+    assert isinstance(sparse.tensordot(a, sb, axes, returntype="sparse"), COO)
+
 
 def test_tensordot_empty():
     x1 = np.empty((0, 0, 0))

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -342,19 +342,34 @@ def test_tensordot(a_shape, b_shape, axes):
     a = sa.todense()
     b = sb.todense()
 
-    assert_eq(np.tensordot(a, b, axes), sparse.tensordot(sa, sb, axes))
+    a_b = np.tensordot(a, b, axes)
 
-    assert_eq(np.tensordot(a, b, axes), sparse.tensordot(sa, b, axes))
+    # tests for return_type=None
+    sa_sb = sparse.tensordot(sa, sb, axes)
+    sa_b = sparse.tensordot(sa, b, axes)
+    a_sb = sparse.tensordot(a, sb, axes)
 
-    # assert isinstance(sparse.tensordot(sa, b, axes), COO)
+    assert_eq(a_b, sa_sb)
+    assert_eq(a_b, sa_b)
+    assert_eq(a_b, a_sb)
+    assert isinstance(sa_sb, COO)
+    assert isinstance(sa_b, np.ndarray)
+    assert isinstance(a_sb, np.ndarray)
 
-    assert_eq(np.tensordot(a, b, axes), sparse.tensordot(a, sb, axes))
+    # tests for return_type=COO
+    sa_b = sparse.tensordot(sa, b, axes, return_type=COO)
+    a_sb = sparse.tensordot(a, sb, axes, return_type=COO)
 
-    # assert isinstance(sparse.tensordot(a, sb, axes), COO)
+    assert_eq(a_b, sa_b)
+    assert_eq(a_b, a_sb)
+    assert isinstance(sa_b, COO)
+    assert isinstance(a_sb, COO)
 
-    assert_eq(np.tensordot(a, b, axes), sparse.tensordot(a, sb, axes, return_type=COO))
+    # tests for return_type=np.ndarray
+    sa_sb = sparse.tensordot(sa, sb, axes, return_type=np.ndarray)
 
-    assert isinstance(sparse.tensordot(a, sb, axes, return_type=COO), COO)
+    assert_eq(a_b, sa_sb)
+    assert isinstance(sa_sb, np.ndarray)
 
 
 def test_tensordot_empty():

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -352,6 +352,10 @@ def test_tensordot(a_shape, b_shape, axes):
 
     # assert isinstance(sparse.tensordot(a, sb, axes), COO)
 
+    assert_eq(
+        np.tensordot(a, b, axes), sparse.tensordot(a, sb, axes, returntype="sparse")
+    )
+
 
 def test_tensordot_empty():
     x1 = np.empty((0, 0, 0))

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -353,10 +353,10 @@ def test_tensordot(a_shape, b_shape, axes):
     # assert isinstance(sparse.tensordot(a, sb, axes), COO)
 
     assert_eq(
-        np.tensordot(a, b, axes), sparse.tensordot(a, sb, axes, returntype="sparse")
+        np.tensordot(a, b, axes), sparse.tensordot(a, sb, axes, return_type=COO)
     )
 
-    assert isinstance(sparse.tensordot(a, sb, axes, returntype="sparse"), COO)
+    assert isinstance(sparse.tensordot(a, sb, axes, return_type=COO), COO)
 
 
 def test_tensordot_empty():


### PR DESCRIPTION
Enhancement of sparse.tenserdot: choose return type. See #348.
The goal is to let the user decide of which type the output of tensordot is. The options are returntype="sparse", "dense" or "auto" (sparse if both arguments are sparse, otherwise dense).

To date only works for returntype="sparse" in the case that the first array is dense and the second array is sparse. The other cases will be implemented in the future.

I am very thankful for suggestions for improvement, especially concerning perfomance.