### PR TITLE
Add nnz parameter to sparse.random

### DIFF
--- a/sparse/_utils.py
+++ b/sparse/_utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import functools
 from collections.abc import Iterable
 from numbers import Integral
@@ -456,3 +457,28 @@ def check_consistent_fill_value(arrays):
                 "is different from a fill_value of {!s} in the first "
                 "argument.".format(i, arg.fill_value, fv)
             )
+
+
+try:
+    nullcontext = contextlib.nullcontext
+except AttributeError:
+    # Shim for Python 3.6.
+    class nullcontext(contextlib.AbstractContextManager):
+        """Context manager that does no additional processing.
+
+        Used as a stand-in for a normal context manager, when a particular
+        block of code is only sometimes used with a normal context manager:
+
+        cm = optional_cm if condition else nullcontext()
+        with cm:
+            # Perform operation, using optional_cm if condition is True
+        """
+
+        def __init__(self, enter_result=None):
+            self.enter_result = enter_result
+
+        def __enter__(self):
+            return self.enter_result
+
+        def __exit__(self, *excinfo):
+            pass

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1595,7 +1595,6 @@ def test_random_invalid_density_and_nnz(density, nnz):
         sparse.random((1,), density, nnz=nnz)
 
 
-
 def test_two_random_unequal():
     s1 = sparse.random((2, 3, 4), 0.3)
     s2 = sparse.random((2, 3, 4), 0.3)

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1578,6 +1578,29 @@ def test_random_shape(shape, density):
     assert np.floor(expected_nnz) <= s.nnz <= np.ceil(expected_nnz)
 
 
+@pytest.mark.parametrize(
+    "shape, density, nnz",
+    [
+        ((1,), 1, 1),
+        ((2,), 0.5, 1),
+        ((2, 2), 0.5, 2),
+        ((5,), 0.5, 2),
+        ((5, 5), 0.12, 3),
+        ((7,), 0.2857142857142857, 2),
+        # 6 / (50*50) == 0.0024, but int(0.0024 * (50*50)) == 5
+        ((50, 50), 0.0025, 6),
+    ],
+)
+def test_random_nnz(shape, density, nnz):
+    sd = sparse.random(shape, density)
+    sz = sparse.random(shape, nnz=nnz)
+
+    assert isinstance(sd, COO)
+    assert isinstance(sz, COO)
+
+    assert sd.nnz == sz.nnz == nnz
+
+
 def test_two_random_unequal():
     s1 = sparse.random((2, 3, 4), 0.3)
     s2 = sparse.random((2, 3, 4), 0.3)


### PR DESCRIPTION
Currently, `sparse.random` uses the `density` argument to determine
the number of non-zero elements in the generated array. If the exact
number of non-zero elements is required, one might try to compute
density as `nnz / np.prod(shape)`, which might give a wrong result
for large values due to a floating-point error.

This PR adds a new, optional `nnz` argument to `sparse.random` that,
if specified, overrides `density` and allows a caller to create
a random array with the exact number of non-zero elements.