### PR TITLE
use correct pointer type for coo shape

### DIFF
--- a/sparse/_coo/numba_extension.py
+++ b/sparse/_coo/numba_extension.py
@@ -52,7 +52,7 @@ class COOType(types.Type):
 
     @property
     def shape_type(self):
-        return types.UniTuple(types.int64, self.ndim)
+        return types.UniTuple(types.intp, self.ndim)
 
     @property
     def fill_value_type(self):

--- a/sparse/_coo/numba_extension.py
+++ b/sparse/_coo/numba_extension.py
@@ -52,7 +52,8 @@ class COOType(types.Type):
 
     @property
     def shape_type(self):
-        return types.UniTuple(types.intp, self.ndim)
+        dt = numba.np.numpy_support.from_dtype(self.coords_dtype)
+        return types.UniTuple(at, self.ndim)
 
     @property
     def fill_value_type(self):

--- a/sparse/_coo/numba_extension.py
+++ b/sparse/_coo/numba_extension.py
@@ -53,7 +53,7 @@ class COOType(types.Type):
     @property
     def shape_type(self):
         dt = numba.np.numpy_support.from_dtype(self.coords_dtype)
-        return types.UniTuple(at, self.ndim)
+        return types.UniTuple(dt, self.ndim)
 
     @property
     def fill_value_type(self):


### PR DESCRIPTION
The suggested `self.self.coords_dtype` did not work for the construction of types.UniTuple():

```
[   73s] >       return self.data[ref(key)]
[   73s] E       TypeError: Failed in nopython mode pipeline (step: nopython mode backend)
[   73s] E       cannot create weak reference to 'numpy.dtype' object
```

But using numba's correct integer type for pointers works.

Fixes #420