### PR TITLE
Use smaller dtypes in coords when possible

### DIFF
--- a/sparse/_compressed/common.py
+++ b/sparse/_compressed/common.py
@@ -36,7 +36,11 @@ def concatenate(arrays, axis=0, compressed_axes=None):
             ptr_list.append(arr.indptr)
             continue
         ptr_list.append(arr.indptr[1:])
+
+    total_nnz = np.sum([arr.nnz for arr in arrays], dtype=np.intp)
+    indptr_dtype = np.min_scalar_type(total_nnz)
     indptr = np.concatenate(ptr_list)
+    indptr = indptr.astype(indptr_dtype)
     indices = np.concatenate([arr.indices for arr in arrays])
     data = np.concatenate([arr.data for arr in arrays])
     ptr_len = arrays[0].indptr.shape[0]
@@ -81,14 +85,19 @@ def stack(arrays, axis=0, compressed_axes=None):
     for i in range(len(arrays)):
         shape = list(arrays[i].shape)
         shape.insert(axis, 1)
-        arrays[i] = arrays[i].reshape(shape).change_compressed_axes((axis,))
+        print("array", i, "indptr", arrays[i].indptr)
+        arrays[i]
+        arrays[i] = arrays[i].reshape(shape, compressed_axes=(axis,))
         if i == 0:
             ptr_list.append(arrays[i].indptr)
             continue
         ptr_list.append(arrays[i].indptr[1:])
 
     shape[axis] = len(arrays)
+    total_nnz = np.sum([arr.nnz for arr in arrays], dtype=np.intp)
+    indptr_dtype = np.min_scalar_type(total_nnz)
     indptr = np.concatenate(ptr_list)
+    indptr = indptr.astype(indptr_dtype)
     indices = np.concatenate([arr.indices for arr in arrays])
     data = np.concatenate([arr.data for arr in arrays])
     ptr_len = arrays[0].indptr.shape[0]

--- a/sparse/_compressed/indexing.py
+++ b/sparse/_compressed/indexing.py
@@ -117,7 +117,7 @@ def getitem(x, key):
         compressed_axes = (0,)  # defaults to 0
         row_size = starts.size
 
-    indptr = np.empty(row_size + 1, dtype=np.intp)
+    indptr = np.empty(row_size + 1, dtype=x.indptr.dtype)
     indptr[0] = 0
     if pos_slice:
         arg = get_slicing_selection(x.data, x.indices, indptr, starts, ends, cols)
@@ -128,13 +128,13 @@ def getitem(x, key):
     size = np.prod(shape[1:])
 
     if not np.any(uncompressed_inds):  # only indexing compressed axes
-        uncompressed = uncompress_dimension(indptr)
+        uncompressed = uncompress_dimension(indptr, indices.dtype)
         if len(shape) == 1:
             indices = uncompressed
             indptr = None
         else:
             indices = uncompressed % size
-            indptr = np.empty(shape[0] + 1, dtype=np.intp)
+            indptr = np.empty(shape[0] + 1, dtype=np.min_scalar_type(indices.size + 1))
             indptr[0] = 0
             np.cumsum(
                 np.bincount(uncompressed // size, minlength=shape[0]), out=indptr[1:]
@@ -144,7 +144,7 @@ def getitem(x, key):
             indptr = None
         else:
             uncompressed = indices // size
-            indptr = np.empty(shape[0] + 1, dtype=np.intp)
+            indptr = np.empty(shape[0] + 1, dtype=np.min_scalar_type(indices.size + 1))
             indptr[0] = 0
             np.cumsum(np.bincount(uncompressed, minlength=shape[0]), out=indptr[1:])
             indices = indices % size

--- a/sparse/_coo/common.py
+++ b/sparse/_coo/common.py
@@ -170,8 +170,9 @@ def concatenate(arrays, axis=0):
     shape = list(arrays[0].shape)
     shape[axis] = dim
 
+    out_dtype = np.min_scalar_type(max(shape))
     data = np.concatenate([x.data for x in arrays])
-    coords = np.concatenate([x.coords for x in arrays], axis=1)
+    coords = np.concatenate([x.coords for x in arrays], axis=1).astype(out_dtype)
 
     dim = 0
     for x in arrays:
@@ -719,8 +720,12 @@ def roll(a, shift, axis=None):
                 "If 'shift' is a 1D sequence, " "'axis' must have equal length."
             )
 
+        shift_dtype = np.min_scalar_type(min(shift))  # for negative shifts
+        max_dtype = np.min_scalar_type(max(a.shape) + max(shift))
+        out_dtype = np.promote_types(shift_dtype, max_dtype)
+
         # shift elements
-        coords, data = np.copy(a.coords), np.copy(a.data)
+        coords, data = a.coords.astype(out_dtype), np.copy(a.data)
         for sh, ax in zip(shift, axis):
             coords[ax] += sh
             coords[ax] %= a.shape[ax]

--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -242,13 +242,12 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
                 shape = tuple((self.coords.max(axis=1) + 1))
             else:
                 shape = ()
-        # if not isinstance(shape, Iterable):
-        #    shape = (shape,)
 
         try:
             coords_dtype = np.min_scalar_type(max(shape) - 1)
         except:
             coords_dtype = np.intp
+
         super().__init__(shape, fill_value=fill_value)
         self.coords = self.coords.astype(coords_dtype, copy=False)
 

--- a/sparse/_coo/indexing.py
+++ b/sparse/_coo/indexing.py
@@ -6,7 +6,7 @@ import numpy as np
 from itertools import zip_longest
 
 from .._slicing import normalize_index
-from .._utils import _zero_of_dtype, equivalent
+from .._utils import _zero_of_dtype, equivalent, min_signed_type
 
 
 def getitem(x, index):
@@ -95,8 +95,11 @@ def getitem(x, index):
             continue
         # Add to the shape and transform the coords in the case of a slice.
         elif isinstance(ind, slice):
+            signed_type = min_signed_type(x.shape[i])
             shape.append(len(range(ind.start, ind.stop, ind.step)))
-            coords.append((x.coords[i, mask] - ind.start) // ind.step)
+            coords.append(
+                (x.coords[i, mask].astype(signed_type) - ind.start) // ind.step
+            )
             i += 1
             if ind.step < 0:
                 sorted = False

--- a/sparse/_utils.py
+++ b/sparse/_utils.py
@@ -461,3 +461,21 @@ def check_consistent_fill_value(arrays):
                 "is different from a fill_value of {!s} in the first "
                 "argument.".format(i, arg.fill_value, fv)
             )
+
+
+def min_signed_type(scalar):
+    """
+    Returns the smallest signed dtype that can be used to store the given scalar.
+
+    Parameters
+    ----------
+    scalar : int
+    """
+    if abs(scalar) < 128:
+        return np.int8
+    elif abs(scalar) < 32768:
+        return np.int16
+    elif abs(scalar) < 2147483648:
+        return np.int32
+    else:
+        return np.int64


### PR DESCRIPTION
Closes #249.

Allows different sized dtypes to be used to store `coords`, `indices`, and `indptr` of `COO` and `GCXS` arrays.