### PR TITLE
Add fancy indexing support for DOK item assignment

### DIFF
--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -309,39 +309,38 @@ class DOK(SparseArray):
             return self.fill_value
 
     def __setitem__(self, key, value):
+        value = np.asanyarray(value, dtype=self.dtype)
+
+        # 1D fancy indexing
         if (
-            isinstance(key, tuple)
-            and len(key) == self.ndim
-            and all(isinstance(k, Iterable) for k in key)
+            self.ndim == 1
+            and isinstance(key, Iterable)
+            and all(isinstance(i, (int, np.integer)) for i in key)
         ):
-            if all(len(key[0]) == len(k) for k in key[1:]):
-                self._fancy_setitem(key, value)
-                return
+            key = (key,)
+
+        if isinstance(key, tuple) and all(isinstance(k, Iterable) for k in key):
+            if len(key) != self.ndim:
+                raise NotImplementedError(
+                    f"Index sequences for all {self.ndim} array dimensions needed!"
+                )
+            if not all(len(key[0]) == len(k) for k in key):
+                raise IndexError("Unequal length of index sequences!")
+            self._fancy_setitem(key, value)
+            return
 
         key = normalize_index(key, self.shape)
-        value = np.asanyarray(value)
-
-        value = value.astype(self.dtype)
 
         key_list = [int(k) if isinstance(k, Integral) else k for k in key]
 
         self._setitem(key_list, value)
 
     def _fancy_setitem(self, idxs, values):
-        if not isinstance(idxs, tuple):  # one dimension, one argument
-            idxs = (idxs,)
-        if len(idxs) != self.ndim:
-            raise NotImplementedError(
-                f"Index sequences for all {self.ndim} array dimensions needed!"
-            )
         idxs = tuple(np.asanyarray(idxs) for idxs in idxs)
-        if not (isinstance(k.dtype, Integral) for k in idxs):
+        if not all(np.issubdtype(k.dtype, np.integer) for k in idxs):
             raise IndexError("Indices must be sequences of integer types!")
-        if not all(idxs[0].shape == k.shape for k in idxs[1:]):
-            raise IndexError("Unequal length of index sequences!")
         if idxs[0].ndim != 1:
             raise IndexError("Indices are not 1d sequences!")
-        values = np.asanyarray(values, self.dtype)
         if values.ndim == 0:
             values = np.full(idxs[0].size, values, self.dtype)
         elif values.ndim > 1:

--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -314,7 +314,7 @@ class DOK(SparseArray):
             if all(len(key[0]) == len(k) for k in key[1:]):
                 self._fancy_setitem(key, value)
                 return
-            
+
         key = normalize_index(key, self.shape)
         value = np.asanyarray(value)
 

--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -309,7 +309,7 @@ class DOK(SparseArray):
             return self.fill_value
 
     def __setitem__(self, key, value):
-        value = np.asanyarray(value, dtype=self.dtype)
+        value = np.asarray(value, dtype=self.dtype)
 
         # 1D fancy indexing
         if (

--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -309,8 +309,11 @@ class DOK(SparseArray):
             return self.fill_value
 
     def __setitem__(self, key, value):
-        if isinstance(key, tuple) and len(key) == self.ndim\
-            and all(isinstance(k, Iterable) for k in key):
+        if (
+            isinstance(key, tuple)
+            and len(key) == self.ndim
+            and all(isinstance(k, Iterable) for k in key)
+        ):
             if all(len(key[0]) == len(k) for k in key[1:]):
                 self._fancy_setitem(key, value)
                 return
@@ -328,30 +331,32 @@ class DOK(SparseArray):
         if not isinstance(idxs, tuple):  # one dimension, one argument
             idxs = (idxs,)
         if len(idxs) != self.ndim:
-            raise NotImplementedError(f'Index sequences for all {self.ndim} array dimensions needed!')
+            raise NotImplementedError(
+                f"Index sequences for all {self.ndim} array dimensions needed!"
+            )
         idxs = tuple(np.asanyarray(idxs) for idxs in idxs)
         if not (isinstance(k.dtype, Integral) for k in idxs):
-            raise IndexError('Indices must be sequences of integer types!')
+            raise IndexError("Indices must be sequences of integer types!")
         if not all(idxs[0].shape == k.shape for k in idxs[1:]):
-            raise IndexError('Unequal length of index sequences!')
+            raise IndexError("Unequal length of index sequences!")
         if idxs[0].ndim != 1:
-            raise IndexError('Indices are not 1d sequences!')
+            raise IndexError("Indices are not 1d sequences!")
         values = np.asanyarray(values, self.dtype)
         if values.ndim == 0:
             values = np.full(idxs[0].size, values, self.dtype)
         elif values.ndim > 1:
-            raise ValueError(f'Dimension of values ({values.ndim}) must be 0 or 1!')
+            raise ValueError(f"Dimension of values ({values.ndim}) must be 0 or 1!")
         if not idxs[0].shape == values.shape:
-            raise ValueError(f'Shape mismatch of indices ({idxs[0].shape}) and values ({values.shape})!')
+            raise ValueError(
+                f"Shape mismatch of indices ({idxs[0].shape}) and values ({values.shape})!"
+            )
         fill_value = self.fill_value
         data = self.data
         for idx, value in zip(zip(*idxs), values):
-            # self._setitem(k, value)  # costly equality checks
             if not value == fill_value:
                 data[idx] = value
             elif idx in data:
                 del data[idx]
-
 
     def _setitem(self, key_list, value):
         value_missing_dims = (

--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -1,4 +1,5 @@
 from numbers import Integral
+from collections.abc import Iterable
 
 import numpy as np
 
@@ -308,6 +309,12 @@ class DOK(SparseArray):
             return self.fill_value
 
     def __setitem__(self, key, value):
+        if isinstance(key, tuple) and len(key) == self.ndim\
+            and all(isinstance(k, Iterable) for k in key):
+            if all(len(key[0]) == len(k) for k in key[1:]):
+                self._fancy_setitem(key, value)
+                return
+            
         key = normalize_index(key, self.shape)
         value = np.asanyarray(value)
 
@@ -316,6 +323,35 @@ class DOK(SparseArray):
         key_list = [int(k) if isinstance(k, Integral) else k for k in key]
 
         self._setitem(key_list, value)
+
+    def _fancy_setitem(self, idxs, values):
+        if not isinstance(idxs, tuple):  # one dimension, one argument
+            idxs = (idxs,)
+        if len(idxs) != self.ndim:
+            raise NotImplementedError(f'Index sequences for all {self.ndim} array dimensions needed!')
+        idxs = tuple(np.asanyarray(idxs) for idxs in idxs)
+        if not (isinstance(k.dtype, Integral) for k in idxs):
+            raise IndexError('Indices must be sequences of integer types!')
+        if not all(idxs[0].shape == k.shape for k in idxs[1:]):
+            raise IndexError('Unequal length of index sequences!')
+        if idxs[0].ndim != 1:
+            raise IndexError('Indices are not 1d sequences!')
+        values = np.asanyarray(values, self.dtype)
+        if values.ndim == 0:
+            values = np.full(idxs[0].size, values, self.dtype)
+        elif values.ndim > 1:
+            raise ValueError(f'Dimension of values ({values.ndim}) must be 0 or 1!')
+        if not idxs[0].shape == values.shape:
+            raise ValueError(f'Shape mismatch of indices ({idxs[0].shape}) and values ({values.shape})!')
+        fill_value = self.fill_value
+        data = self.data
+        for idx, value in zip(zip(*idxs), values):
+            # self._setitem(k, value)  # costly equality checks
+            if not value == fill_value:
+                data[idx] = value
+            elif idx in data:
+                del data[idx]
+
 
     def _setitem(self, key_list, value):
         value_missing_dims = (

--- a/sparse/tests/test_dok.py
+++ b/sparse/tests/test_dok.py
@@ -98,6 +98,7 @@ def test_getitem(shape, density):
         ((2, 3), ([0, 1], [1, 2]), np.random.rand(2)),
         ((2, 3), ([0, 1], [1, 2]), np.random.rand()),
         ((4,), ([1, 3]), np.random.rand()),
+        ((2, 3), ([0, 1], [1, 2]), 0),
     ],
 )
 def test_setitem(shape, index, value):
@@ -115,7 +116,7 @@ def test_setitem(shape, index, value):
     [
         ((2, 3), ([0, 1.5], [1, 2]), np.random.rand()),
         ((2, 3), ([0, 1], [1]), np.random.rand()),
-        ((2, 3), ([[0, 1]], [1, 2]), np.random.rand()),
+        ((2, 3), ([[0], [1]], [1, 2]), np.random.rand()),
     ],
 )
 def test_setitem_index_error(shape, index, value):
@@ -141,7 +142,9 @@ def test_setitem_notimplemented_error(shape, index, value):
 @pytest.mark.parametrize(
     "shape, index, value",
     [
-        ((2, 3), ([0, 1], [1, 2]), np.random.rand((1, 2))),
+        ((2, 3), ([0, 1], [1, 2]), np.random.rand(1, 2)),
+        ((2, 3), ([0, 1], [1, 2]), np.random.rand(3)),
+        ((2,), 1, np.random.rand(2)),
     ],
 )
 def test_setitem_value_error(shape, index, value):

--- a/sparse/tests/test_dok.py
+++ b/sparse/tests/test_dok.py
@@ -97,6 +97,7 @@ def test_getitem(shape, density):
         ((2, 3), (0, 2), np.random.rand()),
         ((2, 3), ([0, 1], [1, 2]), np.random.rand(2)),
         ((2, 3), ([0, 1], [1, 2]), np.random.rand()),
+        ((4,), ([1, 3]), np.random.rand()),
     ],
 )
 def test_setitem(shape, index, value):
@@ -107,6 +108,34 @@ def test_setitem(shape, index, value):
     x[index] = value
 
     assert_eq(x, s)
+
+
+@pytest.mark.parametrize(
+    "shape, index, value",
+    [
+        ((2, 3), ([0, 1.5], [1, 2]), np.random.rand()),
+        ((2, 3), ([0, 1], [1]), np.random.rand()),
+        ((2, 3), ([[0, 1]], [1, 2]), np.random.rand()),
+    ],
+)
+def test_setitem_index_error(shape, index, value):
+    s = sparse.random(shape, 0.5, format="dok")
+
+    with pytest.raises(IndexError):
+        s[index] = value
+
+
+@pytest.mark.parametrize(
+    "shape, index, value",
+    [
+        ((2, 3), ([0, 1],), np.random.rand()),
+    ],
+)
+def test_setitem_notimplemented_error(shape, index, value):
+    s = sparse.random(shape, 0.5, format="dok")
+
+    with pytest.raises(NotImplementedError):
+        s[index] = value
 
 
 def test_default_dtype():

--- a/sparse/tests/test_dok.py
+++ b/sparse/tests/test_dok.py
@@ -95,6 +95,8 @@ def test_getitem(shape, density):
         ((2, 3), (slice(1, 2), 1), np.random.rand()),
         ((2, 3), (slice(1, 2), 1), np.random.rand(1)),
         ((2, 3), (0, 2), np.random.rand()),
+        ((2, 3), ([0, 1], [1, 2]), np.random.rand(2)),
+        ((2, 3), ([0, 1], [1, 2]), np.random.rand()),
     ],
 )
 def test_setitem(shape, index, value):

--- a/sparse/tests/test_dok.py
+++ b/sparse/tests/test_dok.py
@@ -138,6 +138,19 @@ def test_setitem_notimplemented_error(shape, index, value):
         s[index] = value
 
 
+@pytest.mark.parametrize(
+    "shape, index, value",
+    [
+        ((2, 3), ([0, 1], [1, 2]), np.random.rand((1, 2))),
+    ],
+)
+def test_setitem_value_error(shape, index, value):
+    s = sparse.random(shape, 0.5, format="dok")
+
+    with pytest.raises(ValueError):
+        s[index] = value
+
+
 def test_default_dtype():
     s = DOK((5,))
 


### PR DESCRIPTION
Modify `__setitem__` to support a subset of advanced/fancy indexing where all dimensions are indexed. This uses @stschroe's gist [here](https://gist.github.com/stschroe/7c4660774835258c06b2be968eb49204#file-sparse_dok_indexer-py).

We also need `__getitem__`, but we thought we'd submit that as a separate PR.