### PR TITLE
Add slicing and subset of fancy indexing to DOK array access

### DIFF
--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -345,6 +345,7 @@ class DOK(SparseArray):
         )
 
     def _fancy_getitem(self, key):
+        """Subset of fancy indexing, when all dimensions are accessed"""
         new_data = {}
         for i, k in enumerate(zip(*key)):
             if k in self.data:
@@ -357,6 +358,7 @@ class DOK(SparseArray):
         )
 
     def _filter_by_key(self, coords, slice_key):
+        """Filter data coordinates to be within given slice """
         filter_arr = np.ones(coords.shape[0], dtype=bool)
         for coords_in_dim, sl in zip(coords.T, slice_key):
             filter_arr *= (
@@ -499,9 +501,7 @@ class DOK(SparseArray):
 
 
 def to_slice(k):
-    """Convert integer indices to one-element slices.
-
-    It'll make sense at some point. ;)
+    """Convert integer indices to one-element slices for consistency
     """
     if isinstance(k, Integral):
         return slice(k, k + 1, 1)

--- a/sparse/tests/test_dok.py
+++ b/sparse/tests/test_dok.py
@@ -79,6 +79,24 @@ def test_getitem(shape, density):
 
 
 @pytest.mark.parametrize(
+    "shape, density, indices",
+    [
+        ((2, 3), 0.5, (slice(1),)),
+        ((5, 5), 0.5, (slice(0, 4, 2),)),
+        ((10, 10), 0.2, (slice(5), slice(0, 10, 2))),
+    ],
+)
+def test_getitem_slice(shape, density, indices):
+    s = sparse.random(shape, density, format="dok")
+    x = s.todense()
+
+    sparse_sliced = s[indices]
+    dense_sliced = x[indices]
+
+    assert_eq(sparse_sliced.todense(), dense_sliced)
+
+
+@pytest.mark.parametrize(
     "shape, index, value",
     [
         ((2,), slice(None), np.random.rand()),

--- a/sparse/tests/test_dok.py
+++ b/sparse/tests/test_dok.py
@@ -83,7 +83,8 @@ def test_getitem(shape, density):
     [
         ((2, 3), 0.5, (slice(1),)),
         ((5, 5), 0.5, (slice(0, 4, 2),)),
-        ((10, 10), 0.2, (slice(5), slice(0, 10, 2))),
+        ((10, 10), 0.2, (slice(5), slice(0, 10, 3))),
+        ((5, 5), 0.5, (slice(0, 4, 4), slice(0, 4, 4))),
     ],
 )
 def test_getitem_slice(shape, density, indices):

--- a/sparse/tests/test_dok.py
+++ b/sparse/tests/test_dok.py
@@ -85,6 +85,7 @@ def test_getitem(shape, density):
         ((5, 5), 0.5, (slice(0, 4, 2),)),
         ((10, 10), 0.2, (slice(5), slice(0, 10, 3))),
         ((5, 5), 0.5, (slice(0, 4, 4), slice(0, 4, 4))),
+        ((5, 5), 0.5, (1, slice(0, 4, 1))),
     ],
 )
 def test_getitem_slice(shape, density, indices):

--- a/sparse/tests/test_dok.py
+++ b/sparse/tests/test_dok.py
@@ -67,13 +67,14 @@ def test_construct(shape, data):
 
 @pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4)])
 @pytest.mark.parametrize("density", [0.1, 0.3, 0.5, 0.7])
-def test_getitem(shape, density):
+def test_getitem_single(shape, density):
     s = sparse.random(shape, density, format="dok")
     x = s.todense()
 
     for _ in range(s.nnz):
         idx = np.random.randint(np.prod(shape))
         idx = np.unravel_index(idx, shape)
+        print(idx)
 
         assert np.isclose(s[idx], x[idx])
 
@@ -82,13 +83,14 @@ def test_getitem(shape, density):
     "shape, density, indices",
     [
         ((2, 3), 0.5, (slice(1),)),
-        ((5, 5), 0.5, (slice(0, 4, 2),)),
+        ((5, 5), 0.2, (slice(0, 4, 2),)),
         ((10, 10), 0.2, (slice(5), slice(0, 10, 3))),
         ((5, 5), 0.5, (slice(0, 4, 4), slice(0, 4, 4))),
-        ((5, 5), 0.5, (1, slice(0, 4, 1))),
+        ((5, 5), 0.4, (1, slice(0, 4, 1))),
+        ((10, 10), 0.8, ([0, 4, 5], [3, 2, 4])),
     ],
 )
-def test_getitem_slice(shape, density, indices):
+def test_getitem(shape, density, indices):
     s = sparse.random(shape, density, format="dok")
     x = s.todense()
 
@@ -96,6 +98,34 @@ def test_getitem_slice(shape, density, indices):
     dense_sliced = x[indices]
 
     assert_eq(sparse_sliced.todense(), dense_sliced)
+
+
+@pytest.mark.parametrize(
+    "shape, density, indices",
+    [
+        ((10, 10), 0.8, ([0, 4, 5],)),
+        ((5, 5, 5), 0.5, ([1, 2, 3], [0, 2, 2])),
+    ],
+)
+def test_getitem_notimplemented_error(shape, density, indices):
+    s = sparse.random(shape, density, format="dok")
+
+    with pytest.raises(NotImplementedError):
+        s[indices]
+
+
+@pytest.mark.parametrize(
+    "shape, density, indices",
+    [
+        ((10, 10), 0.8, ([0, 4, 5], [0, 2])),
+        ((5, 5, 5), 0.5, ([1, 2, 3], [0], [2, 3, 4])),
+    ],
+)
+def test_getitem_index_error(shape, density, indices):
+    s = sparse.random(shape, density, format="dok")
+
+    with pytest.raises(IndexError):
+        s[indices]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Extend DOK `__getitem__` to support slicing and fancy indexing when all dimensions are indexed.