### PR TITLE
Implement equality comparison for DOK arrays

### DIFF
--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -472,6 +472,31 @@ class DOK(SparseArray):
 
     __repr__ = __str__
 
+    def __eq__(self, o):
+        if isinstance(o, DOK):
+            if self.fill_value == o.fill_value:
+                return DOK.from_numpy(self.todense() == o.todense())
+            else:
+                # the only possible Trues are identical coordinates with matching values
+                common_keys = set(self.data.keys()).intersect(set(o.data.keys()))
+                filtered = [self.data[k] == o.data[k] for k in common_keys]
+                new_data = dict(zip(common_keys, filtered))
+                return DOK(shape=self.shape, data=new_data, dtype=bool, fill_value=False)
+
+        
+        # o is a single value
+        if self.fill_value == o:
+            return DOK.from_numpy(self.todense() == o)
+        else:
+            coords_array = np.asarray(list(self.data.keys()))
+            values_array = np.asarray(list(self.data.values()))
+            filtered = values_array == o
+            filtered_coords = [tuple(c) for c in coords_array[filtered]]
+            new_data = dict(zip(filtered_coords, [True for _ in range(len(filtered_coords))]))
+            return DOK(shape=self.shape, data=new_data, dtype=bool, fill_value=False)
+
+        
+
     def todense(self):
         """
         Convert this :obj:`DOK` array into a Numpy array.

--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -475,7 +475,12 @@ class DOK(SparseArray):
     def __eq__(self, o):
         # dense array
         if isinstance(o, np.ndarray):
-            return DOK.from_numpy(self.todense() == o)
+            ret = self.todense() == o
+            if isinstance(ret, bool):
+                raise ValueError(
+                    f"operands could not be broadcast together with shapes {self.shape} {o.shape}"
+                )
+            return DOK.from_numpy(ret)
 
         from ._coo import COO
 

--- a/sparse/_umath.py
+++ b/sparse/_umath.py
@@ -425,9 +425,16 @@ class _Elemwise:
         processed_args = []
         out_type = GCXS
 
+        sparse_args = [arg for arg in args if isinstance(arg, SparseArray)]
+
+        if all(isinstance(arg, DOK) for arg in sparse_args):
+            out_type = DOK
+        elif all(isinstance(arg, GCXS) for arg in sparse_args):
+            out_type = GCXS
+        else:
+            out_type = COO
+
         for arg in args:
-            if isinstance(arg, COO) or isinstance(arg, DOK):
-                out_type = COO
             if isinstance(arg, scipy.sparse.spmatrix):
                 processed_args.append(COO.from_scipy_sparse(arg))
             elif isscalar(arg) or isinstance(arg, np.ndarray):

--- a/sparse/tests/test_dok.py
+++ b/sparse/tests/test_dok.py
@@ -204,48 +204,6 @@ def test_setitem_value_error(shape, index, value):
         s[index] = value
 
 
-@pytest.mark.parametrize(
-    "other",
-    [
-        5,
-        0,
-        np.random.rand(10, 10),
-        np.random.rand(1, 10),
-        sparse.random((10, 10), 0.5, format="dok"),
-        sparse.random((1, 10), 0.5, format="dok"),
-        sparse.random((1, 10), 0.5),
-        sparse.random((10, 10), 0.5),
-        sparse.random((10, 10), 0.5, fill_value=5, format="dok"),
-        sparse.random((10, 10), 0.5, fill_value=5),
-    ],
-)
-def test_eq(other):
-    slf = sparse.random((10, 10), 0.5, format="dok")
-    eq_sparse = slf == other
-
-    if hasattr(other, "todense"):
-        other = other.todense()
-
-    eq_dense = slf.todense() == other
-
-    assert_eq(eq_sparse, eq_dense)
-
-
-@pytest.mark.parametrize(
-    "other",
-    [
-        np.random.rand(5, 10),
-        sparse.random((5, 10), 0.5, format="dok"),
-        sparse.random((10, 5), 0.5),
-    ],
-)
-def test_eq_value_error(other):
-    slf = sparse.random((10, 10), 0.5, format="dok")
-
-    with pytest.raises(ValueError):
-        slf == other
-
-
 def test_default_dtype():
     s = DOK((5,))
 

--- a/sparse/tests/test_dok.py
+++ b/sparse/tests/test_dok.py
@@ -204,6 +204,33 @@ def test_setitem_value_error(shape, index, value):
         s[index] = value
 
 
+@pytest.mark.parametrize(
+    "other",
+    [
+        5,
+        0,
+        np.random.rand(10, 10),
+        np.random.rand(1, 10),
+        sparse.random((10, 10), 0.5, format="dok"),
+        sparse.random((1, 10), 0.5, format="dok"),
+        sparse.random((1, 10), 0.5),
+        sparse.random((10, 10), 0.5),
+        sparse.random((10, 10), 0.5, fill_value=5, format="dok"),
+        sparse.random((10, 10), 0.5, fill_value=5),
+    ],
+)
+def test_eq(other):
+    slf = sparse.random((10, 10), 0.5, format="dok")
+    eq_sparse = slf == other
+
+    if hasattr(other, "todense"):
+        other = other.todense()
+
+    eq_dense = slf.todense() == other
+
+    assert_eq(eq_sparse, eq_dense)
+
+
 def test_default_dtype():
     s = DOK((5,))
 

--- a/sparse/tests/test_dok.py
+++ b/sparse/tests/test_dok.py
@@ -231,6 +231,21 @@ def test_eq(other):
     assert_eq(eq_sparse, eq_dense)
 
 
+@pytest.mark.parametrize(
+    "other",
+    [
+        np.random.rand(5, 10),
+        sparse.random((5, 10), 0.5, format="dok"),
+        sparse.random((10, 5), 0.5),
+    ],
+)
+def test_eq_value_error(other):
+    slf = sparse.random((10, 10), 0.5, format="dok")
+
+    with pytest.raises(ValueError):
+        slf == other
+
+
 def test_default_dtype():
     s = DOK((5,))
 

--- a/sparse/tests/test_elemwise.py
+++ b/sparse/tests/test_elemwise.py
@@ -2,7 +2,7 @@ import numpy as np
 import sparse
 import pytest
 import operator
-from sparse import COO
+from sparse import COO, DOK
 from sparse._compressed import GCXS
 from sparse._utils import assert_eq, random_value_array
 
@@ -29,7 +29,7 @@ from sparse._utils import assert_eq, random_value_array
         abs,
     ],
 )
-@pytest.mark.parametrize("format", [COO, GCXS])
+@pytest.mark.parametrize("format", [COO, GCXS, DOK])
 def test_elemwise(func, format):
     s = sparse.random((2, 3, 4), density=0.5, format=format)
     x = s.todense()
@@ -61,7 +61,7 @@ def test_elemwise(func, format):
         lambda x, out: x.round(decimals=2, out=out),
     ],
 )
-@pytest.mark.parametrize("format", [COO, GCXS])
+@pytest.mark.parametrize("format", [COO, GCXS, DOK])
 def test_elemwise_inplace(func, format):
     s = sparse.random((2, 3, 4), density=0.5, format=format)
     x = s.todense()
@@ -88,7 +88,7 @@ def test_elemwise_inplace(func, format):
         ((2, 2, 2), (1, 1, 1)),
     ],
 )
-@pytest.mark.parametrize("format", [COO, GCXS])
+@pytest.mark.parametrize("format", [COO, GCXS, DOK])
 def test_elemwise_mixed(shape1, shape2, format):
     s1 = sparse.random(shape1, density=0.5, format=format)
     x2 = np.random.rand(*shape2)
@@ -98,7 +98,7 @@ def test_elemwise_mixed(shape1, shape2, format):
     assert_eq(s1 * x2, x1 * x2)
 
 
-@pytest.mark.parametrize("format", [COO, GCXS])
+@pytest.mark.parametrize("format", [COO, GCXS, DOK])
 def test_elemwise_mixed_empty(format):
     s1 = sparse.random((2, 0, 4), density=0.5, format=format)
     x2 = np.random.rand(2, 0, 4)
@@ -108,7 +108,7 @@ def test_elemwise_mixed_empty(format):
     assert_eq(s1 * x2, x1 * x2)
 
 
-@pytest.mark.parametrize("format", [COO, GCXS])
+@pytest.mark.parametrize("format", [COO, GCXS, DOK])
 def test_elemwise_unsupported(format):
     class A:
         pass
@@ -122,7 +122,7 @@ def test_elemwise_unsupported(format):
     assert sparse.elemwise(operator.add, s1, x2) is NotImplemented
 
 
-@pytest.mark.parametrize("format", [COO, GCXS])
+@pytest.mark.parametrize("format", [COO, GCXS, DOK])
 def test_elemwise_mixed_broadcast(format):
     s1 = sparse.random((2, 3, 4), density=0.5, format=format)
     s2 = sparse.random(4, density=0.5)
@@ -142,7 +142,7 @@ def test_elemwise_mixed_broadcast(format):
     [operator.mul, operator.add, operator.sub, operator.gt, operator.lt, operator.ne],
 )
 @pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)])
-@pytest.mark.parametrize("format", [COO, GCXS])
+@pytest.mark.parametrize("format", [COO, GCXS, DOK])
 def test_elemwise_binary(func, shape, format):
     xs = sparse.random(shape, density=0.5, format=format)
     ys = sparse.random(shape, density=0.5, format=format)
@@ -155,7 +155,7 @@ def test_elemwise_binary(func, shape, format):
 
 @pytest.mark.parametrize("func", [operator.imul, operator.iadd, operator.isub])
 @pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)])
-@pytest.mark.parametrize("format", [COO, GCXS])
+@pytest.mark.parametrize("format", [COO, GCXS, DOK])
 def test_elemwise_binary_inplace(func, shape, format):
     xs = sparse.random(shape, density=0.5, format=format)
     ys = sparse.random(shape, density=0.5, format=format)
@@ -364,6 +364,8 @@ def test_sparsearray_elemwise(format):
     fs = sparse.elemwise(operator.add, xs, ys)
     if format == "gcxs":
         assert isinstance(fs, GCXS)
+    elif format == "dok":
+        assert isinstance(fs, DOK)
     else:
         assert isinstance(fs, COO)
 
@@ -399,7 +401,7 @@ def test_elemwise_noargs():
 )
 @pytest.mark.filterwarnings("ignore:divide by zero")
 @pytest.mark.filterwarnings("ignore:invalid value")
-@pytest.mark.parametrize("format", [COO, GCXS])
+@pytest.mark.parametrize("format", [COO, GCXS, DOK])
 def test_nonzero_outout_fv_ufunc(func, format):
     xs = sparse.random((2, 3, 4), density=0.5, format=format)
     ys = sparse.random((2, 3, 4), density=0.5, format=format)
@@ -433,7 +435,7 @@ def test_nonzero_outout_fv_ufunc(func, format):
     ],
 )
 @pytest.mark.parametrize("convert_to_np_number", [True, False])
-@pytest.mark.parametrize("format", [COO, GCXS])
+@pytest.mark.parametrize("format", [COO, GCXS, DOK])
 def test_elemwise_scalar(func, scalar, convert_to_np_number, format):
     xs = sparse.random((2, 3, 4), density=0.5, format=format)
     if convert_to_np_number:
@@ -514,7 +516,7 @@ def test_scalar_output_nonzero_fv(func, scalar):
 
 @pytest.mark.parametrize("func", [operator.and_, operator.or_, operator.xor])
 @pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)])
-@pytest.mark.parametrize("format", [COO, GCXS])
+@pytest.mark.parametrize("format", [COO, GCXS, DOK])
 def test_bitwise_binary(func, shape, format):
     # Small arrays need high density to have nnz entries
     # Casting floats to int will result in all zeros, hence the * 100
@@ -529,7 +531,7 @@ def test_bitwise_binary(func, shape, format):
 
 @pytest.mark.parametrize("func", [operator.iand, operator.ior, operator.ixor])
 @pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)])
-@pytest.mark.parametrize("format", [COO, GCXS])
+@pytest.mark.parametrize("format", [COO, GCXS, DOK])
 def test_bitwise_binary_inplace(func, shape, format):
     # Small arrays need high density to have nnz entries
     # Casting floats to int will result in all zeros, hence the * 100


### PR DESCRIPTION
Behaves as closely as possible to `np.ndarray` comparisons
- Single values are broadcast
- Broadcasting for arrays of different shapes is as per `numpy` broadcasting rules
- Always returns a new DOK array of bools

@hameerabbasi I think this is the last operation we need for our use-case over at napari. Please let me know if there's any changes you'd like made!