### PR TITLE
allow for use of different dtypes in coords, indices, and indptr

### DIFF
--- a/sparse/_compressed/common.py
+++ b/sparse/_compressed/common.py
@@ -41,7 +41,7 @@ def concatenate(arrays, axis=0, compressed_axes=None):
     data = np.concatenate([arr.data for arr in arrays])
     ptr_len = arrays[0].indptr.shape[0]
     nnz = arrays[0].nnz
-    total_nnz = sum([arr.nnz for arr in arrays[:-1]])
+    total_nnz = sum(int(arr.nnz) for arr in arrays)
     if not can_store(indptr.dtype, total_nnz):
         indptr = indptr.astype(np.min_scalar_type(total_nnz))
     for i in range(1, len(arrays)):
@@ -96,7 +96,7 @@ def stack(arrays, axis=0, compressed_axes=None):
     data = np.concatenate([arr.data for arr in arrays])
     ptr_len = arrays[0].indptr.shape[0]
     nnz = arrays[0].nnz
-    total_nnz = sum([arr.nnz for arr in arrays[:-1]])
+    total_nnz = sum(int(arr.nnz) for arr in arrays)
     if not can_store(indptr.dtype, total_nnz):
         indptr = indptr.astype(np.min_scalar_type(total_nnz))
     for i in range(1, len(arrays)):

--- a/sparse/_compressed/common.py
+++ b/sparse/_compressed/common.py
@@ -1,5 +1,5 @@
 import numpy as np
-from .._utils import check_consistent_fill_value, normalize_axis
+from .._utils import check_consistent_fill_value, normalize_axis, can_store
 
 
 def concatenate(arrays, axis=0, compressed_axes=None):
@@ -41,6 +41,9 @@ def concatenate(arrays, axis=0, compressed_axes=None):
     data = np.concatenate([arr.data for arr in arrays])
     ptr_len = arrays[0].indptr.shape[0]
     nnz = arrays[0].nnz
+    total_nnz = sum([arr.nnz for arr in arrays[:-1]])
+    if not can_store(indptr.dtype, total_nnz):
+        indptr = indptr.astype(np.min_scalar_type(total_nnz))
     for i in range(1, len(arrays)):
         indptr[ptr_len:] += nnz
         nnz = arrays[i].nnz
@@ -93,6 +96,9 @@ def stack(arrays, axis=0, compressed_axes=None):
     data = np.concatenate([arr.data for arr in arrays])
     ptr_len = arrays[0].indptr.shape[0]
     nnz = arrays[0].nnz
+    total_nnz = sum([arr.nnz for arr in arrays[:-1]])
+    if not can_store(indptr.dtype, total_nnz):
+        indptr = indptr.astype(np.min_scalar_type(total_nnz))
     for i in range(1, len(arrays)):
         indptr[ptr_len:] += nnz
         nnz = arrays[i].nnz

--- a/sparse/_compressed/convert.py
+++ b/sparse/_compressed/convert.py
@@ -123,7 +123,7 @@ def _1d_reshape(x, shape, compressed_axes):
     x_indices = x.indices[:end_idx]
     new_nnz = x_indices.size
     new_linear = np.empty(new_nnz, dtype=np.intp)
-    coords_dtype = get_out_dtype(x.indices, max(new_compressed_shape))
+    coords_dtype = get_out_dtype(x.indices, max(max(new_compressed_shape), x.nnz))
     new_coords = np.empty((2, new_nnz), dtype=coords_dtype)
 
     _linearize(
@@ -227,7 +227,7 @@ def _transpose(x, shape, axes, compressed_axes, transpose=False):
     row_size = np.prod(new_reordered_shape[:axisptr])
     col_size = np.prod(new_reordered_shape[axisptr:])
     new_compressed_shape = np.array((row_size, col_size))
-    coords_dtype = get_out_dtype(x.indices, max(new_compressed_shape))
+    coords_dtype = get_out_dtype(x.indices, max(max(new_compressed_shape), x.nnz))
     new_coords = np.empty((2, x.nnz), dtype=coords_dtype)
 
     _convert_coords(

--- a/sparse/_utils.py
+++ b/sparse/_utils.py
@@ -85,7 +85,7 @@ def random(
     format="coo",
     compressed_axes=None,
     fill_value=None,
-    storage_dtype=None,
+    idx_dtype=None,
 ):
     """Generate a random sparse multidimensional array
 
@@ -198,14 +198,12 @@ def random(
         fill_value=fill_value,
     ).reshape(shape)
 
-    if storage_dtype:
-        if can_store(storage_dtype, max(shape)):
-            ar.coords = ar.coords.astype(storage_dtype)
+    if idx_dtype:
+        if can_store(idx_dtype, max(shape)):
+            ar.coords = ar.coords.astype(idx_dtype)
         else:
             raise ValueError(
-                "cannot cast array with shape {} to dtype {}.".format(
-                    shape, storage_dtype
-                )
+                "cannot cast array with shape {} to dtype {}.".format(shape, idx_dtype)
             )
 
     return ar.asformat(format, compressed_axes=compressed_axes)

--- a/sparse/_utils.py
+++ b/sparse/_utils.py
@@ -196,8 +196,17 @@ def random(
         data,
         shape=elements,
         fill_value=fill_value,
-        storage_dtype=storage_dtype,
     ).reshape(shape)
+
+    if storage_dtype:
+        if can_store(storage_dtype, max(shape)):
+            ar.coords = ar.coords.astype(storage_dtype)
+        else:
+            raise ValueError(
+                "cannot cast array with shape {} to dtype {}.".format(
+                    shape, storage_dtype
+                )
+            )
 
     return ar.asformat(format, compressed_axes=compressed_axes)
 
@@ -478,7 +487,6 @@ def get_out_dtype(arr, scalar):
 
 
 def can_store(dtype, scalar):
-    #  return dtype(scalar) == scalar
     return np.array(scalar, dtype=dtype) == np.array(scalar)
 
 

--- a/sparse/_utils.py
+++ b/sparse/_utils.py
@@ -85,6 +85,7 @@ def random(
     format="coo",
     compressed_axes=None,
     fill_value=None,
+    storage_dtype=None,
 ):
     """Generate a random sparse multidimensional array
 
@@ -190,7 +191,13 @@ def random(
 
     data = data_rvs(nnz)
 
-    ar = COO(ind[None, :], data, shape=elements, fill_value=fill_value).reshape(shape)
+    ar = COO(
+        ind[None, :],
+        data,
+        shape=elements,
+        fill_value=fill_value,
+        storage_dtype=storage_dtype,
+    ).reshape(shape)
 
     return ar.asformat(format, compressed_axes=compressed_axes)
 
@@ -461,3 +468,19 @@ def check_consistent_fill_value(arrays):
                 "is different from a fill_value of {!s} in the first "
                 "argument.".format(i, arg.fill_value, fv)
             )
+
+
+def get_out_dtype(arr, scalar):
+    out_type = arr.dtype
+    if not can_store(out_type, scalar):
+        out_type = np.min_scalar_type(scalar)
+    return out_type
+
+
+def can_store(dtype, scalar):
+    #  return dtype(scalar) == scalar
+    return np.array(scalar, dtype=dtype) == np.array(scalar)
+
+
+def is_unsigned_dtype(dtype):
+    return not np.array(-1, dtype=dtype) == np.array(-1)

--- a/sparse/tests/test_compressed.py
+++ b/sparse/tests/test_compressed.py
@@ -430,3 +430,25 @@ def test_flatten(in_shape):
     e = x.flatten()
 
     assert_eq(e, a)
+
+
+def test_gcxs_valerr():
+    a = np.arange(300)
+    with pytest.raises(ValueError):
+        GCXS.from_numpy(a, storage_dtype=np.int8)
+
+
+def test_upcast():
+    a = sparse.random((50, 50, 50), density=0.1, format="coo", storage_dtype=np.uint8)
+    b = a.asformat("gcxs")
+    assert b.indices.dtype == np.uint16
+
+    a = sparse.random((8, 7, 6), density=0.5, format="gcxs", storage_dtype=np.uint8)
+    assert sparse.concatenate((a, a)).indptr.dtype == np.uint16
+    assert sparse.stack((a, a)).indptr.dtype == np.uint16
+
+
+def test_from_coo():
+    a = sparse.random((5, 5, 5), density=0.1, format="coo")
+    b = GCXS(a)
+    assert_eq(a, b)

--- a/sparse/tests/test_compressed.py
+++ b/sparse/tests/test_compressed.py
@@ -435,20 +435,27 @@ def test_flatten(in_shape):
 def test_gcxs_valerr():
     a = np.arange(300)
     with pytest.raises(ValueError):
-        GCXS.from_numpy(a, storage_dtype=np.int8)
+        GCXS.from_numpy(a, idx_dtype=np.int8)
 
 
 def test_upcast():
-    a = sparse.random((50, 50, 50), density=0.1, format="coo", storage_dtype=np.uint8)
+    a = sparse.random((50, 50, 50), density=0.1, format="coo", idx_dtype=np.uint8)
     b = a.asformat("gcxs")
     assert b.indices.dtype == np.uint16
 
-    a = sparse.random((8, 7, 6), density=0.5, format="gcxs", storage_dtype=np.uint8)
+    a = sparse.random((8, 7, 6), density=0.5, format="gcxs", idx_dtype=np.uint8)
+    b = sparse.random((6, 6, 6), density=0.8, format="gcxs", idx_dtype=np.uint8)
     assert sparse.concatenate((a, a)).indptr.dtype == np.uint16
-    assert sparse.stack((a, a)).indptr.dtype == np.uint16
+    assert sparse.stack((b, b)).indptr.dtype == np.uint16
 
 
 def test_from_coo():
     a = sparse.random((5, 5, 5), density=0.1, format="coo")
     b = GCXS(a)
     assert_eq(a, b)
+
+
+def test_from_coo_valerr():
+    a = sparse.random((25, 25, 25), density=0.01, format="coo")
+    with pytest.raises(ValueError):
+        GCXS.from_coo(a, idx_dtype=np.int8)

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1195,6 +1195,13 @@ class TestRoll:
         with pytest.raises(ValueError):
             sparse.roll(x, *args)
 
+    @pytest.mark.parametrize("dtype", [np.uint8, np.int8])
+    @pytest.mark.parametrize("shift", [300, -300])
+    def test_dtype_errors(self, dtype, shift):
+        x = sparse.random((5, 5, 5), density=0.2, storage_dtype=dtype)
+        with pytest.raises(ValueError):
+            sparse.roll(x, shift)
+
 
 def test_clip():
     x = np.array([[0, 0, 1, 0, 2], [5, 0, 0, 3, 0]])

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -243,7 +243,7 @@ def test_resize(a, b):
 
 
 def test_resize_upcast():
-    s = sparse.random((10, 10, 10), density=0.5, format="coo", storage_dtype=np.uint8)
+    s = sparse.random((10, 10, 10), density=0.5, format="coo", idx_dtype=np.uint8)
     s.resize(600)
     assert s.coords.dtype == np.uint16
 
@@ -378,7 +378,7 @@ def test_reshape_function():
 
 
 def test_reshape_upcast():
-    a = sparse.random((10, 10, 10), density=0.5, format="coo", storage_dtype=np.uint8)
+    a = sparse.random((10, 10, 10), density=0.5, format="coo", idx_dtype=np.uint8)
     assert a.reshape(1000).coords.dtype == np.uint16
 
 
@@ -1209,12 +1209,12 @@ class TestRoll:
     @pytest.mark.parametrize("dtype", [np.uint8, np.int8])
     @pytest.mark.parametrize("shift", [300, -300])
     def test_dtype_errors(self, dtype, shift):
-        x = sparse.random((5, 5, 5), density=0.2, storage_dtype=dtype)
+        x = sparse.random((5, 5, 5), density=0.2, idx_dtype=dtype)
         with pytest.raises(ValueError):
             sparse.roll(x, shift)
 
     def test_unsigned_type_error(self):
-        x = sparse.random((5, 5, 5), density=0.3, storage_dtype=np.uint8)
+        x = sparse.random((5, 5, 5), density=0.3, idx_dtype=np.uint8)
         with pytest.raises(ValueError):
             sparse.roll(x, -1)
 
@@ -1600,4 +1600,9 @@ def test_astype_no_copy():
 def test_coo_valerr():
     a = np.arange(300)
     with pytest.raises(ValueError):
-        COO.from_numpy(a, storage_dtype=np.int8)
+        COO.from_numpy(a, idx_dtype=np.int8)
+
+
+def test_random_idx_dtype():
+    with pytest.raises(ValueError):
+        sparse.random((300,), density=0.1, format="coo", idx_dtype=np.int8)

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -242,6 +242,12 @@ def test_resize(a, b):
     assert_eq(x, s)
 
 
+def test_resize_upcast():
+    s = sparse.random((10, 10, 10), density=0.5, format="coo", storage_dtype=np.uint8)
+    s.resize(600)
+    assert s.coords.dtype == np.uint16
+
+
 @pytest.mark.parametrize("axis1", [-3, -2, -1, 0, 1, 2])
 @pytest.mark.parametrize("axis2", [-3, -2, -1, 0, 1, 2])
 def test_swapaxes(axis1, axis2):
@@ -369,6 +375,11 @@ def test_reshape_function():
     s2 = np.reshape(s, shape)
     assert isinstance(s2, COO)
     assert_eq(s2, x.reshape(shape))
+
+
+def test_reshape_upcast():
+    a = sparse.random((10, 10, 10), density=0.5, format="coo", storage_dtype=np.uint8)
+    assert a.reshape(1000).coords.dtype == np.uint16
 
 
 def test_to_scipy_sparse():
@@ -1202,6 +1213,11 @@ class TestRoll:
         with pytest.raises(ValueError):
             sparse.roll(x, shift)
 
+    def test_unsigned_type_error(self):
+        x = sparse.random((5, 5, 5), density=0.3, storage_dtype=np.uint8)
+        with pytest.raises(ValueError):
+            sparse.roll(x, -1)
+
 
 def test_clip():
     x = np.array([[0, 0, 1, 0, 2], [5, 0, 0, 3, 0]])
@@ -1579,3 +1595,9 @@ def test_astype_no_copy():
     s1 = sparse.random((2, 3, 4), density=0.5)
     s2 = s1.astype(s1.dtype, copy=False)
     assert s1 is s2
+
+
+def test_coo_valerr():
+    a = np.arange(300)
+    with pytest.raises(ValueError):
+        COO.from_numpy(a, storage_dtype=np.int8)


### PR DESCRIPTION
In this version, I've added a `storage_dtype` argument in the `COO` and `GCXS` constructors. For most operations, the result array will use the same storage dtype as the input array. There are a few places where the output is upcast to a larger dtype if the input dtype is too small. I decided to do this because in these situations no error is raised and the output is simply wrong. Where it doesn't make sense to upcast, I have it raise an error. 