### PR TITLE
Document elementwise functions for DOK arrays

### DIFF
--- a/docs/construct.rst
+++ b/docs/construct.rst
@@ -140,7 +140,7 @@ DOK arrays also support fancy indexing assignment if and only if all dimensions 
    s[[0, 2], [2, 1], [0, 1]] = 5
    s[[0, 3], [0, 4], [0, 1]] = [1, 5]
 
-Alongside indexing assignment and retrieval, DOK arrays support any arbitrary broadcasting function
+Alongside indexing assignment and retrieval, :obj:`DOK` arrays support any arbitrary broadcasting function
 to any number of arguments where the arguments can be :obj:`SparseArray` objects, :obj:`scipy.sparse.spmatrix`
 objects, or :obj:`numpy.ndarrays`. 
 
@@ -150,8 +150,19 @@ objects, or :obj:`numpy.ndarrays`.
    y = sparse.random((10, 10), 0.5, format="dok")
    sparse.elemwise(np.add, x, y)
 
-:obj:`DOK` arrays are returned from elemwise functions if and only if all :obj:`SparseArray` objects are
-obj:`DOK` arrays. Otherwise, a :obj:`COO` array or dense array are returned.
+:obj:`DOK` arrays also support standard `__ufunc__` operations and operators, including comparison operators,
+in combination with other objects implementing the `numpy` `ndarray.__array_ufunc__` method. For example,
+the following code will perform elementwise equality comparison on the two arrays
+and return a new boolean :obj:`DOK` array.
+
+.. code-block:: python
+
+   x = sparse.random((10, 10), 0.5, format="dok")
+   y = np.random.random((10, 10))
+   x == y
+
+:obj:`DOK` arrays are returned from elemwise functions and standard `__ufunc__` operations if and only if all 
+:obj:`SparseArray` objects are obj:`DOK` arrays. Otherwise, a :obj:`COO` array or dense array are returned.
 
 At the end, you can convert the :obj:`DOK` array to a :obj:`COO` arrays.
 

--- a/docs/construct.rst
+++ b/docs/construct.rst
@@ -150,7 +150,7 @@ objects, or :obj:`numpy.ndarrays`.
    y = sparse.random((10, 10), 0.5, format="dok")
    sparse.elemwise(np.add, x, y)
 
-:obj:`DOK` arrays also support standard `__ufunc__` operations and operators, including comparison operators,
+:obj:`DOK` arrays also support standard universal operations and operators, including comparison operators,
 in combination with other objects implementing the `numpy` `ndarray.__array_ufunc__` method. For example,
 the following code will perform elementwise equality comparison on the two arrays
 and return a new boolean :obj:`DOK` array.
@@ -161,7 +161,7 @@ and return a new boolean :obj:`DOK` array.
    y = np.random.random((10, 10))
    x == y
 
-:obj:`DOK` arrays are returned from elemwise functions and standard `__ufunc__` operations if and only if all 
+:obj:`DOK` arrays are returned from elemwise functions and standard universal operations if and only if all 
 :obj:`SparseArray` objects are obj:`DOK` arrays. Otherwise, a :obj:`COO` array or dense array are returned.
 
 At the end, you can convert the :obj:`DOK` array to a :obj:`COO` arrays.

--- a/docs/construct.rst
+++ b/docs/construct.rst
@@ -150,7 +150,7 @@ objects, or :obj:`numpy.ndarrays`.
    y = sparse.random((10, 10), 0.5, format="dok")
    sparse.elemwise(np.add, x, y)
 
-:obj:`DOK` arrays also support standard universal operations and operators, including comparison operators,
+:obj:`DOK` arrays also support standard ufuncs and operators, including comparison operators,
 in combination with other objects implementing the `numpy` `ndarray.__array_ufunc__` method. For example,
 the following code will perform elementwise equality comparison on the two arrays
 and return a new boolean :obj:`DOK` array.
@@ -161,7 +161,7 @@ and return a new boolean :obj:`DOK` array.
    y = np.random.random((10, 10))
    x == y
 
-:obj:`DOK` arrays are returned from elemwise functions and standard universal operations if and only if all 
+:obj:`DOK` arrays are returned from elemwise functions and standard ufuncs if and only if all 
 :obj:`SparseArray` objects are obj:`DOK` arrays. Otherwise, a :obj:`COO` array or dense array are returned.
 
 At the end, you can convert the :obj:`DOK` array to a :obj:`COO` arrays.

--- a/docs/construct.rst
+++ b/docs/construct.rst
@@ -140,8 +140,20 @@ DOK arrays also support fancy indexing assignment if and only if all dimensions 
    s[[0, 2], [2, 1], [0, 1]] = 5
    s[[0, 3], [0, 4], [0, 1]] = [1, 5]
 
-At the end, you can convert the :obj:`DOK` array to a :obj:`COO` array, and
-perform arithmetic or other operations on it.
+Alongside indexing assignment and retrieval, DOK arrays support any arbitrary broadcasting function
+to any number of arguments where the arguments can be :obj:`SparseArray` objects, :obj:`scipy.sparse.spmatrix`
+objects, or :obj:`numpy.ndarrays`. 
+
+.. code-block:: python
+
+   x = sparse.random((10, 10), 0.5, format="dok")
+   y = sparse.random((10, 10), 0.5, format="dok")
+   sparse.elemwise(np.add, x, y)
+
+:obj:`DOK` arrays are returned from elemwise functions if and only if all :obj:`SparseArray` objects are
+obj:`DOK` arrays. Otherwise, a :obj:`COO` array or dense array are returned.
+
+At the end, you can convert the :obj:`DOK` array to a :obj:`COO` arrays.
 
 .. code-block:: python
 


### PR DESCRIPTION
@hameerabbasi I've updated the docs to include elementwise operations for DOK arrays. 

At this point I'm not sure whether you want to keep the DOK documentation in Construct Sparse Arrays, or whether you'd like to pull it out as its own section, but please let me know if that's the case, and whether you want more detail on the elementwise operations e.g. more detail on comparisons, etc. As it is, I tried to follow the convention already used for the COO arrays.