### PR TITLE
Fix typo in var function docstring

### DIFF
--- a/sparse/_sparse_array.py
+++ b/sparse/_sparse_array.py
@@ -687,7 +687,7 @@ class SparseArray:
 
     def var(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
         """
-        Compute the variance along the gi66ven axes. Uses all axes by default.
+        Compute the variance along the given axes. Uses all axes by default.
 
         Parameters
         ----------


### PR DESCRIPTION
In the docstring of the `var` function, it says "gi66ven" instead of "given". I assume that this is a typo?
I created a pull request but maybe you would have preferred that I opened an issue instead.