### PR TITLE
Attempt to reformat docstring to match Numpydoc standard.

### DIFF
--- a/sparse/_common.py
+++ b/sparse/_common.py
@@ -1341,6 +1341,7 @@ def full(shape, fill_value, dtype=None, format="coo", compressed_axes=None):
         A format string.
     compressed_axes : iterable, optional
         The axes to compress if returning a GCXS array.
+
     Returns
     -------
     out : SparseArray

--- a/sparse/_common.py
+++ b/sparse/_common.py
@@ -46,7 +46,6 @@ def tensordot(a, b, axes=2, *, return_type=None):
     return_type : {None, COO, np.ndarray}, optional
         Type of returned array.
 
-
     Returns
     -------
     Union[COO, numpy.ndarray]
@@ -497,18 +496,13 @@ def _csr_csr_count_nnz(
     with compressed rows: (a @ b).nnz.
 
     Parameters
-        ----------
-        out_shape : tuple
-            The shape of the output array.
-
-        indptr : ndarray
-            The empty index pointer array for the output.
-
-        a_indices, a_indptr : np.ndarray
-            The indices and index pointer array of ``a``.
-
-        b_data, b_indices, b_indptr : np.ndarray
-            The indices and index pointer array of ``b``.
+    ----------
+    out_shape : tuple
+        The shape of the output array.
+    a_indices, a_indptr : np.ndarray
+        The indices and index pointer array of ``a``.
+    b_data, b_indices, b_indptr : np.ndarray
+        The indices and index pointer array of ``b``.
     """
     n_row, n_col = out_shape
     nnz = 0
@@ -534,18 +528,15 @@ def _csr_ndarray_count_nnz(
     numpy array: (a @ b).nnz.
 
     Parameters
-        ----------
-        out_shape : tuple
-            The shape of the output array.
-
-        indptr : ndarray
-            The empty index pointer array for the output.
-
-        a_indices, a_indptr : np.ndarray
-            The indices and index pointer array of ``a``.
-
-        b : np.ndarray
-            The second input array ``b``.
+    ----------
+    out_shape : tuple
+        The shape of the output array.
+    indptr : ndarray
+        The empty index pointer array for the output.
+    a_indices, a_indptr : np.ndarray
+        The indices and index pointer array of ``a``.
+    b : np.ndarray
+        The second input array ``b``.
     """
     nnz = 0
     for i in range(out_shape[0]):
@@ -569,18 +560,15 @@ def _csc_ndarray_count_nnz(
     numpy array: (a @ b).nnz.
 
     Parameters
-        ----------
-        a_shape, b_shape : tuple
-            The shapes of the input arrays.
-
-        indptr : ndarray
-            The empty index pointer array for the output.
-
-        a_indices, a_indptr : np.ndarray
-            The indices and index pointer array of ``a``.
-
-        b : np.ndarray
-            The second input array ``b``.
+    ----------
+    a_shape, b_shape : tuple
+        The shapes of the input arrays.
+    indptr : ndarray
+        The empty index pointer array for the output.
+    a_indices, a_indptr : np.ndarray
+        The indices and index pointer array of ``a``.
+    b : np.ndarray
+        The second input array ``b``.
     """
     nnz = 0
     mask = np.full(a_shape[0], -1)
@@ -620,10 +608,8 @@ def _dot_csr_csr_type(dt1, dt2):
         ----------
         out_shape : tuple
             The shape of the output array.
-
         a_data, a_indices, a_indptr : np.ndarray
             The data, indices, and index pointer arrays of ``a``.
-
         b_data, b_indices, b_indptr : np.ndarray
             The data, indices, and index pointer arrays of ``b``.
         """
@@ -697,10 +683,8 @@ def _dot_csr_ndarray_type(dt1, dt2):
         ----------
         a_data, a_indices, a_indptr : np.ndarray
             The data, indices, and index pointers of ``a``.
-
         b : np.ndarray
             The second input array ``b``.
-
         out_shape : Tuple[int]
             The shape of the output array.
         """
@@ -739,10 +723,8 @@ def _dot_csr_ndarray_type_sparse(dt1, dt2):
         ----------
         a_data, a_indices, a_indptr : np.ndarray
             The data, indices, and index pointers of ``a``.
-
         b : np.ndarray
             The second input array ``b``.
-
         out_shape : Tuple[int]
             The shape of the output array.
         """
@@ -792,10 +774,8 @@ def _dot_csc_ndarray_type_sparse(dt1, dt2):
         ----------
         a_data, a_indices, a_indptr : np.ndarray
             The data, indices, and index pointers of ``a``.
-
         b : np.ndarray
             The second input array ``b``.
-
         a_shape, b_shape : Tuple[int]
             The shapes of the input arrays.
         """
@@ -858,10 +838,8 @@ def _dot_csc_ndarray_type(dt1, dt2):
         ----------
         a_data, a_indices, a_indptr : np.ndarray
             The data, indices, and index pointers of ``a``.
-
         b : np.ndarray
             The second input array ``b``.
-
         a_shape, b_shape : Tuple[int]
             The shapes of the input arrays.
         """
@@ -893,10 +871,8 @@ def _dot_ndarray_csc_type(dt1, dt2):
         ----------
         a : np.ndarray
             The input array ``a``.
-
         b_data, b_indices, b_indptr : np.ndarray
             The data, indices, and index pointers of ``b``.
-
         out_shape : Tuple[int]
             The shape of the output array.
         """
@@ -932,10 +908,8 @@ def _dot_coo_coo_type(dt1, dt2):
         ----------
         a_shape, b_shape : tuple
             The shapes of the input arrays.
-
         a_data, a_coords : np.ndarray
             The data and coordinates of ``a``.
-
         b_data, b_coords : np.ndarray
             The data and coordinates of ``b``.
         """
@@ -1006,10 +980,8 @@ def _dot_coo_ndarray_type(dt1, dt2):
         ----------
         data1, coords1 : np.ndarray
             The data and coordinates of ``s1``.
-
         array2 : np.ndarray
             The second input array ``x2``.
-
         out_shape : Tuple[int]
             The output shape.
         """
@@ -1050,10 +1022,8 @@ def _dot_coo_ndarray_type_sparse(dt1, dt2):
         ----------
         data1, coords1 : np.ndarray
             The data and coordinates of ``s1``.
-
         array2 : np.ndarray
             The second input array ``x2``.
-
         out_shape : Tuple[int]
             The output shape.
         """
@@ -1105,10 +1075,8 @@ def _dot_ndarray_coo_type(dt1, dt2):
         ----------
         array1 : np.ndarray
             The input array ``x1``.
-
         data2, coords2 : np.ndarray
             The data and coordinates of ``s2``.
-
         out_shape : Tuple[int]
             The output shape.
         """
@@ -1142,10 +1110,8 @@ def _dot_ndarray_coo_type_sparse(dt1, dt2):
         ----------
         array1 : np.ndarray
             The input array ``x1``.
-
         data2, coords2 : np.ndarray
             The data and coordinates of ``s2``.
-
         out_shape : Tuple[int]
             The output shape.
         """

--- a/sparse/_compressed/compressed.py
+++ b/sparse/_compressed/compressed.py
@@ -605,7 +605,7 @@ class GCXS(SparseArray, NDArrayOperatorsMixin):
         See Also
         --------
         numpy.ndarray.reshape : The equivalent Numpy function.
-        sparse.COO.reshape: The equivalent COO function.
+        sparse.COO.reshape : The equivalent COO function.
 
         Notes
         -----

--- a/sparse/_compressed/compressed.py
+++ b/sparse/_compressed/compressed.py
@@ -508,10 +508,12 @@ class GCXS(SparseArray, NDArrayOperatorsMixin):
         ----------
         format : str
             A format string.
+
         Returns
         -------
         out : SparseArray
             The converted array.
+
         Raises
         ------
         NotImplementedError
@@ -604,6 +606,7 @@ class GCXS(SparseArray, NDArrayOperatorsMixin):
         --------
         numpy.ndarray.reshape : The equivalent Numpy function.
         sparse.COO.reshape: The equivalent COO function.
+
         Notes
         -----
         The :code:`order` parameter is provided just for compatibility with

--- a/sparse/_coo/common.py
+++ b/sparse/_coo/common.py
@@ -351,7 +351,7 @@ def nansum(x, axis=None, keepdims=False, dtype=None, out=None):
         The axes along which to sum. Uses all axes by default.
     keepdims : bool, optional
         Whether or not to keep the dimensions of the original array.
-    dtype: numpy.dtype
+    dtype : numpy.dtype
         The data type of the output array.
 
     Returns
@@ -381,7 +381,7 @@ def nanmean(x, axis=None, keepdims=False, dtype=None, out=None):
         The axes along which to compute the mean. Uses all axes by default.
     keepdims : bool, optional
         Whether or not to keep the dimensions of the original array.
-    dtype: numpy.dtype
+    dtype : numpy.dtype
         The data type of the output array.
 
     Returns
@@ -435,7 +435,7 @@ def nanmax(x, axis=None, keepdims=False, dtype=None, out=None):
         The axes along which to maximize. Uses all axes by default.
     keepdims : bool, optional
         Whether or not to keep the dimensions of the original array.
-    dtype: numpy.dtype
+    dtype : numpy.dtype
         The data type of the output array.
 
     Returns
@@ -471,7 +471,7 @@ def nanmin(x, axis=None, keepdims=False, dtype=None, out=None):
         The axes along which to minimize. Uses all axes by default.
     keepdims : bool, optional
         Whether or not to keep the dimensions of the original array.
-    dtype: numpy.dtype
+    dtype : numpy.dtype
         The data type of the output array.
 
     Returns
@@ -508,7 +508,7 @@ def nanprod(x, axis=None, keepdims=False, dtype=None, out=None):
         The axes along which to multiply. Uses all axes by default.
     keepdims : bool, optional
         Whether or not to keep the dimensions of the original array.
-    dtype: numpy.dtype
+    dtype : numpy.dtype
         The data type of the output array.
 
     Returns
@@ -581,7 +581,7 @@ def argwhere(a):
 
     Parameters
     ----------
-    a: array_like
+    a : array_like
         Input data.
 
     Returns
@@ -645,7 +645,7 @@ def nanreduce(x, method, identity=None, axis=None, keepdims=False, **kwargs):
         The axes along which to perform the reduction. Uses all axes by default.
     keepdims : bool, optional
         Whether or not to keep the dimensions of the original array.
-    kwargs : dict
+    **kwargs : dict
         Any extra arguments to pass to the reduction operation.
 
     Returns
@@ -673,7 +673,7 @@ def roll(a, shift, axis=None):
 
     Parameters
     ----------
-    x : COO
+    a : COO
         Input array
     shift : int or tuple of ints
         Number of index positions that elements are shifted. If a tuple is
@@ -761,11 +761,11 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
 
     Parameters
     ----------
-    a: COO
+    a : COO
         The array to perform the operation on.
-    offset: int, optional
+    offset : int, optional
         Offset of the diagonal from the main diagonal. Defaults to main diagonal (0).
-    axis1: int, optional
+    axis1 : int, optional
         First axis from which the diagonals should be taken.
         Defaults to first axis (0).
     axis2 : int, optional
@@ -802,7 +802,7 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
 
     See Also
     --------
-    :obj:`numpy.diagonal`: NumPy equivalent function
+    :obj:`numpy.diagonal` : NumPy equivalent function
     """
     from .core import COO
 
@@ -831,9 +831,9 @@ def diagonalize(a, axis=0):
 
     Parameters
     ----------
-    a: Union[COO, np.ndarray, scipy.sparse.spmatrix]
+    a : Union[COO, np.ndarray, scipy.sparse.spmatrix]
         The array to diagonalize.
-    axis: int, optional
+    axis : int, optional
         The axis to diagonalize. Defaults to first axis (0).
 
     Examples
@@ -864,7 +864,7 @@ def diagonalize(a, axis=0):
 
     See Also
     --------
-    :obj:`numpy.diag`: NumPy equivalent for 1D array
+    :obj:`numpy.diag` : NumPy equivalent for 1D array
     """
     from .core import COO, as_coo
 
@@ -959,10 +959,8 @@ def _diagonal_idx(coordlist, axis1, axis2, offset):
     ----------
     coordlist : list of lists
         Coordinate indices.
-
     axis1, axis2 : int
         The axes of the diagonal.
-
     offset : int
         Offset of the diagonal from the main diagonal. Defaults to main diagonal (0).
     """
@@ -984,7 +982,7 @@ def clip(a, a_min=None, a_max=None, out=None):
 
     Parameters
     ----------
-    a:
+    a
     a_min : scalar or `SparseArray` or `None`
         Minimum value. If `None`, clipping is not performed on lower
         interval edge.
@@ -1013,7 +1011,7 @@ def clip(a, a_min=None, a_max=None, out=None):
     >>> sparse.clip(x, a_min=1, a_max=2).todense() # doctest: +NORMALIZE_WHITESPACE
     array([1, 1, 1, 1, 2, 2])
 
-    See also
+    See Also
     --------
     numpy.clip : Equivalent NumPy function
     """

--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -977,21 +977,27 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
     def reshape(self, shape, order="C"):
         """
         Returns a new :obj:`COO` array that is a reshaped version of this array.
+
         Parameters
         ----------
         shape : tuple[int]
             The desired shape of the output array.
+
         Returns
         -------
         COO
             The reshaped output array.
+
         See Also
         --------
         numpy.ndarray.reshape : The equivalent Numpy function.
+
         Notes
         -----
+
         The :code:`order` parameter is provided just for compatibility with
         Numpy and isn't actually supported.
+
         Examples
         --------
         >>> s = COO.from_numpy(np.arange(25))

--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -805,8 +805,10 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
 
         See Also
         --------
-        :obj:`COO.transpose` : A method where you can specify the order of the axes.
-        numpy.ndarray.T : Numpy equivalent property.
+        :obj:`COO.transpose` :
+            A method where you can specify the order of the axes.
+        numpy.ndarray.T :
+            Numpy equivalent property.
 
         Examples
         --------
@@ -845,7 +847,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         ----------
         axis1 : int
             first axis to swap
-        axis2: int
+        axis2 : int
             second axis to swap
 
         Returns
@@ -920,12 +922,6 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         The nonzero coordinates of a flattened version of this array. Note that
         the coordinates may be out of order.
 
-        Parameters
-        ----------
-        signed : bool, optional
-            Whether to use a signed datatype for the output array. :code:`False`
-            by default.
-
         Returns
         -------
         numpy.ndarray
@@ -994,7 +990,6 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
 
         Notes
         -----
-
         The :code:`order` parameter is provided just for compatibility with
         Numpy and isn't actually supported.
 
@@ -1120,7 +1115,6 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         ------
         ValueError
             If the array is not two-dimensional.
-
         ValueError
             If all the array doesn't zero fill-values.
 
@@ -1168,7 +1162,6 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         ------
         ValueError
             If the array is not two-dimensional.
-
         ValueError
             If all the array doesn't have zero fill-values.
 
@@ -1209,7 +1202,6 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         ------
         ValueError
             If the array is not two-dimensional.
-
         ValueError
             If the array doesn't have zero fill-values.
 
@@ -1337,7 +1329,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         ValueError
             If the operand cannot be broadcast to the given shape.
 
-        See also
+        See Also
         --------
         :obj:`numpy.broadcast_to` : NumPy equivalent function
         """
@@ -1361,7 +1353,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
             The dense array.
 
         Raises
-        -------
+        ------
         ValueError
             If the returned array would be too large.
 
@@ -1478,10 +1470,14 @@ def as_coo(x, shape=None, fill_value=None, idx_dtype=None):
 
     See Also
     --------
-    SparseArray.asformat : A utility function to convert between formats in this library.
-    COO.from_numpy : Convert a Numpy array to :obj:`COO`.
-    COO.from_scipy_sparse : Convert a SciPy sparse matrix to :obj:`COO`.
-    COO.from_iter : Convert an iterable to :obj:`COO`.
+    SparseArray.asformat :
+        A utility function to convert between formats in this library.
+    COO.from_numpy :
+        Convert a Numpy array to :obj:`COO`.
+    COO.from_scipy_sparse :
+        Convert a SciPy sparse matrix to :obj:`COO`.
+    COO.from_iter :
+        Convert an iterable to :obj:`COO`.
     """
     if hasattr(x, "shape") and shape is not None:
         raise ValueError(
@@ -1551,7 +1547,7 @@ def _grouped_reduce(x, groups, method, **kwargs):
         contiguous.
     method : np.ufunc
         The :code:`ufunc` to use to perform the reduction.
-    kwargs : dict
+    **kwargs : dict
         The kwargs to pass to the :code:`ufunc`'s :code:`reduceat`
         function.
 

--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -249,13 +249,11 @@ class DOK(SparseArray, NDArrayOperatorsMixin):
         -------
         str
             The storage format of this array.
-
         See Also
         -------
         COO.format : Equivalent :obj:`COO` array property.
         GCXS.format : Equivalent :obj:`GCXS` array property.
         scipy.sparse.dok_matrix.format : The Scipy equivalent property.
-
         Examples
         -------
         >>> import sparse

--- a/sparse/_io.py
+++ b/sparse/_io.py
@@ -22,7 +22,7 @@ def save_npz(filename, matrix, compressed=True):
     compressed : bool
         Whether to save in compressed or uncompressed mode
 
-    Example
+    Examples
     --------
     Store sparse matrix to disk, and load it again:
 
@@ -85,7 +85,7 @@ def load_npz(filename):
     SparseArray
         The sparse matrix at path ``filename``.
 
-    Example
+    Examples
     --------
     See :obj:`save_npz` for usage examples.
 

--- a/sparse/_slicing.py
+++ b/sparse/_slicing.py
@@ -277,8 +277,8 @@ def replace_none(idx, dim):
 
     Parameters
     ----------
-    idx: slice or other index
-    dim: dimension length
+    idx : slice or other index
+    dim : dimension length
 
     Examples
     --------

--- a/sparse/_sparse_array.py
+++ b/sparse/_sparse_array.py
@@ -333,7 +333,7 @@ class SparseArray:
             The axes along which to perform the reduction. Uses all axes by default.
         keepdims : bool, optional
             Whether or not to keep the dimensions of the original array.
-        kwargs : dict
+        **kwargs : dict
             Any extra arguments to pass to the reduction operation.
 
         See Also
@@ -403,7 +403,7 @@ class SparseArray:
             The axes along which to sum. Uses all axes by default.
         keepdims : bool, optional
             Whether or not to keep the dimensions of the original array.
-        dtype: numpy.dtype
+        dtype : numpy.dtype
             The data type of the output array.
 
         Returns
@@ -428,7 +428,7 @@ class SparseArray:
             The axes along which to maximize. Uses all axes by default.
         keepdims : bool, optional
             Whether or not to keep the dimensions of the original array.
-        dtype: numpy.dtype
+        out : numpy.dtype
             The data type of the output array.
 
         Returns
@@ -499,7 +499,7 @@ class SparseArray:
             The axes along which to minimize. Uses all axes by default.
         keepdims : bool, optional
             Whether or not to keep the dimensions of the original array.
-        dtype: numpy.dtype
+        out : numpy.dtype
             The data type of the output array.
 
         Returns
@@ -526,7 +526,7 @@ class SparseArray:
             The axes along which to multiply. Uses all axes by default.
         keepdims : bool, optional
             Whether or not to keep the dimensions of the original array.
-        dtype: numpy.dtype
+        dtype : numpy.dtype
             The data type of the output array.
 
         Returns
@@ -546,10 +546,12 @@ class SparseArray:
         """
         Evenly round to the given number of decimals.
 
-        See also
+        See Also
         --------
-        :obj:`numpy.round` : NumPy equivalent ufunc.
-        :obj:`COO.elemwise`: Apply an arbitrary element-wise function to one or two
+        :obj:`numpy.round` :
+            NumPy equivalent ufunc.
+        :obj:`COO.elemwise` :
+            Apply an arbitrary element-wise function to one or two
             arguments.
         """
         if out is not None and not isinstance(out, tuple):
@@ -584,11 +586,14 @@ class SparseArray:
         """
         Copy of the array, cast to a specified type.
 
-        See also
+        See Also
         --------
-        scipy.sparse.coo_matrix.astype : SciPy sparse equivalent function
-        numpy.ndarray.astype : NumPy equivalent ufunc.
-        :obj:`COO.elemwise`: Apply an arbitrary element-wise function to one or two
+        scipy.sparse.coo_matrix.astype :
+            SciPy sparse equivalent function
+        numpy.ndarray.astype :
+            NumPy equivalent ufunc.
+        :obj:`COO.elemwise` :
+            Apply an arbitrary element-wise function to one or two
             arguments.
         """
         # this matches numpy's behavior
@@ -608,7 +613,7 @@ class SparseArray:
             The axes along which to compute the mean. Uses all axes by default.
         keepdims : bool, optional
             Whether or not to keep the dimensions of the original array.
-        dtype: numpy.dtype
+        dtype : numpy.dtype
             The data type of the output array.
 
         Returns
@@ -695,9 +700,9 @@ class SparseArray:
             The axes along which to compute the variance. Uses all axes by default.
         dtype : numpy.dtype, optional
             The output datatype.
-        out: SparseArray, optional
+        out : SparseArray, optional
             The array to write the output to.
-        ddof: int
+        ddof : int
             The degrees of freedom.
         keepdims : bool, optional
             Whether or not to keep the dimensions of the original array.
@@ -793,9 +798,9 @@ class SparseArray:
             all axes by default.
         dtype : numpy.dtype, optional
             The output datatype.
-        out: SparseArray, optional
+        out : SparseArray, optional
             The array to write the output to.
-        ddof: int
+        ddof : int
             The degrees of freedom.
         keepdims : bool, optional
             Whether or not to keep the dimensions of the original array.

--- a/sparse/_umath.py
+++ b/sparse/_umath.py
@@ -330,6 +330,7 @@ def _get_matching_coords(coords, params):
         The input coordinates.
     params : list[Union[bool, none]]
         The broadcast parameters.
+
     Returns
     -------
     numpy.ndarray

--- a/sparse/_umath.py
+++ b/sparse/_umath.py
@@ -17,10 +17,10 @@ def elemwise(func, *args, **kwargs):
     ----------
     func : Callable
         The function to apply. Must support broadcasting.
-    args : tuple, optional
+    *args : tuple, optional
         The arguments to the function. Can be :obj:`SparseArray` objects
         or :obj:`scipy.sparse.spmatrix` objects.
-    kwargs : dict, optional
+    **kwargs : dict, optional
         Any additional arguments to pass to the function.
 
     Returns
@@ -36,7 +36,8 @@ def elemwise(func, *args, **kwargs):
 
     See Also
     --------
-    :obj:`numpy.ufunc` : A similar Numpy construct. Note that any :code:`ufunc` can be used
+    :obj:`numpy.ufunc` :
+        A similar Numpy construct. Note that any :code:`ufunc` can be used
         as the :code:`func` input to this function.
 
     Notes
@@ -96,7 +97,7 @@ def _get_nary_broadcast_shape(*shapes):
 
     Parameters
     ----------
-    shapes : tuple[tuple[int]]
+    *shapes : tuple[tuple[int]]
         The shapes to broadcast.
 
     Returns
@@ -215,7 +216,7 @@ def _get_reduced_shape(shape, params):
 
     Parameters
     ----------
-    coords : np.ndarray
+    shape : np.ndarray
         The coordinates to reduce.
     params : list
         The params from which to check which dimensions to get.
@@ -299,7 +300,7 @@ def _cartesian_product(*arrays):
 
     Parameters
     ----------
-    arrays : Tuple[np.ndarray]
+    *arrays : Tuple[np.ndarray]
         The arrays to get a cartesian product of. Always sorted with respect
         to the original array.
 
@@ -374,7 +375,7 @@ def broadcast_to(x, shape):
     ValueError
         If the operand cannot be broadcast to the given shape.
 
-    See also
+    See Also
     --------
     :obj:`numpy.broadcast_to` : NumPy equivalent function
     """
@@ -413,9 +414,9 @@ class _Elemwise:
         ----------
         func : types.Callable
             The function to compute
-        args : tuple[Union[SparseArray, ndarray, scipy.sparse.spmatrix]]
+        *args : tuple[Union[SparseArray, ndarray, scipy.sparse.spmatrix]]
             The arguments to compute the function on.
-        kwargs : dict
+        **kwargs : dict
             Extra arguments to pass to the function.
         """
         from ._coo import COO
@@ -689,7 +690,7 @@ class _Elemwise:
 
         Parameters
         ----------
-        args : Tuple[COO]
+        *args : Tuple[COO]
             The input :obj:`COO` arrays.
         return_midx : bool
             Whether to return matched indices or matched arrays. Matching

--- a/sparse/_utils.py
+++ b/sparse/_utils.py
@@ -91,12 +91,12 @@ def random(
 
     Parameters
     ----------
-    shape: Tuple[int]
+    shape : Tuple[int]
         Shape of the array
-    density: float, optional
+    density : float, optional
         Density of the generated array; default is 0.01.
         Mutually exclusive with `nnz`.
-    nnz: int, optional
+    nnz : int, optional
         Number of nonzero elements in the generated array.
         Mutually exclusive with `density`.
     random_state : Union[numpy.random.RandomState, int], optional
@@ -120,14 +120,11 @@ def random(
 
     See Also
     --------
-    :obj:`scipy.sparse.rand`
-        Equivalent Scipy function.
-    :obj:`numpy.random.rand`
-        Similar Numpy function.
+    :obj:`scipy.sparse.rand` : Equivalent Scipy function.
+    :obj:`numpy.random.rand` : Similar Numpy function.
 
     Examples
     --------
-
     >>> from sparse import random
     >>> from scipy import stats
     >>> rvs = lambda x: stats.poisson(25, loc=10).rvs(x, random_state=np.random.RandomState(1))
@@ -376,7 +373,7 @@ def check_compressed_axes(ndim, compressed_axes):
 
     Parameters
     ----------
-    shape : int
+    ndim : int
     compressed_axes : Iterable
 
     Raises
@@ -406,7 +403,7 @@ def check_zero_fill_value(*args):
 
     Parameters
     ----------
-    args : Iterable[SparseArray]
+    *args : Iterable[SparseArray]
 
     Raises
     ------


### PR DESCRIPTION
This uses an automatic reformatter to fix some of the common mistakes.
A few manual were needed, for example Numpydoc really want section to be separated by empty lines, or it start to say that `Return`, `------` are parameter of a function.

Spaces around colons or not in parameters have a different semantic meaning when parsing – it may not show in sphinx html, but internally the data is different and is messed up for crosslinks.

This also fixed a couple of parameter names typos (x/a or coord/shape/ndim inversion ...)