### PR TITLE
[WIP] CSR/ CSC Elemwise

### DIFF
--- a/sparse/_compressed/compressed.py
+++ b/sparse/_compressed/compressed.py
@@ -16,6 +16,7 @@ from .._utils import (
     can_store,
     check_zero_fill_value,
     check_compressed_axes,
+    _zero_of_dtype,
     equivalent,
 )
 from .._coo.core import COO
@@ -144,7 +145,7 @@ class GCXS(SparseArray, NDArrayOperatorsMixin):
         shape=None,
         compressed_axes=None,
         prune=False,
-        fill_value=0,
+        fill_value=None,
         idx_dtype=None,
     ):
 
@@ -171,6 +172,10 @@ class GCXS(SparseArray, NDArrayOperatorsMixin):
                 arg.fill_value,
             )
 
+        self.data, self.indices, self.indptr = arg
+
+        if fill_value is None:
+            fill_value = _zero_of_dtype(self.data.dtype)
         if shape is None:
             raise ValueError("missing `shape` argument")
 
@@ -178,8 +183,6 @@ class GCXS(SparseArray, NDArrayOperatorsMixin):
 
         if len(shape) == 1:
             compressed_axes = None
-
-        self.data, self.indices, self.indptr = arg
 
         if self.data.ndim != 1:
             raise ValueError("data must be a scalar or 1-dimensional.")
@@ -813,7 +816,12 @@ class GCXS(SparseArray, NDArrayOperatorsMixin):
 
 class _Compressed2d(GCXS):
     def __init__(
-        self, arg, shape=None, compressed_axes=None, prune=False, fill_value=0
+        self,
+        arg,
+        shape=None,
+        compressed_axes=None,
+        prune=False,
+        fill_value=None,
     ):
         if not hasattr(arg, "shape") and shape is None:
             raise ValueError("missing `shape` argument")
@@ -856,7 +864,7 @@ class CSR(_Compressed2d):
     Sparse supports 2-D CSR.
     """
 
-    def __init__(self, arg, shape=None, prune=False, fill_value=0):
+    def __init__(self, arg, shape=None, prune=False, fill_value=None):
         super().__init__(arg, shape=shape, compressed_axes=(0,), fill_value=fill_value)
 
     @classmethod
@@ -881,7 +889,7 @@ class CSC(_Compressed2d):
     Sparse supports 2-D CSC.
     """
 
-    def __init__(self, arg, shape=None, prune=False, fill_value=0):
+    def __init__(self, arg, shape=None, prune=False, fill_value=None):
         super().__init__(arg, shape=shape, compressed_axes=(1,), fill_value=fill_value)
 
     @classmethod

--- a/sparse/_compressed/elemwise.py
+++ b/sparse/_compressed/elemwise.py
@@ -1,0 +1,117 @@
+from functools import lru_cache
+from typing import Callable
+
+import numpy as np
+import scipy.sparse
+from numba import njit
+
+
+def op_unary(func, a):
+    res = a.copy()
+    res.data = func(a.data)
+    return res
+
+
+@lru_cache(maxsize=None)
+def _numba_d(func):
+    return njit(lambda *x: func(*x))
+
+
+def binary_op(func, a, b):
+    func = _numba_d(func)
+    return op_union_indices(func, a, b)
+
+
+def op_union_indices(
+    op: Callable, a: scipy.sparse.csr_matrix, b: scipy.sparse.csr_matrix, *, default_value=0
+):
+    assert a.shape == b.shape
+
+    if type(a) != type(b):
+        b = type(a)(b)
+    # a.sort_indices()
+    # b.sort_indices()
+
+    # TODO: numpy is weird with bools here
+    out_dtype = np.array(op(a.data[0], b.data[0])).dtype
+    default_value = out_dtype.type(default_value)
+    return type(a)(
+        op_union_indices_csr_csr(
+            op,
+            a.indptr,
+            a.indices,
+            a.data,
+            b.indptr,
+            b.indices,
+            b.data,
+            out_dtype=out_dtype,
+            default_value=default_value,
+        ),
+        a.shape,
+    )
+
+
+@njit
+def op_union_indices_csr_csr(
+    op: Callable,
+    a_indptr: np.ndarray,
+    a_indices: np.ndarray,
+    a_data: np.ndarray,
+    b_indptr: np.ndarray,
+    b_indices: np.ndarray,
+    b_data: np.ndarray,
+    out_dtype,
+    default_value,
+):
+    out_indptr = np.zeros_like(a_indptr)
+    out_indices = np.zeros(len(a_indices) + len(b_indices), dtype=a_indices.dtype)
+    out_data = np.zeros(len(out_indices), dtype=out_dtype)
+
+    out_idx = 0
+
+    for i in range(len(a_indptr) - 1):
+
+        a_idx = a_indptr[i]
+        a_end = a_indptr[i + 1]
+        b_idx = b_indptr[i]
+        b_end = b_indptr[i + 1]
+
+        while (a_idx < a_end) and (b_idx < b_end):
+            a_j = a_indices[a_idx]
+            b_j = b_indices[b_idx]
+            if a_j < b_j:
+                out_indices[out_idx] = a_j
+                out_data[out_idx] = op(a_data[a_idx], default_value)
+                a_idx += 1
+            elif b_j < a_j:
+                out_indices[out_idx] = b_j
+                out_data[out_idx] = op(default_value, b_data[b_idx])
+                b_idx += 1
+            else:
+                out_indices[out_idx] = a_j
+                out_data[out_idx] = op(a_data[a_idx], b_data[b_idx])
+                a_idx += 1
+                b_idx += 1
+            out_idx += 1
+
+        # Catch up the other set
+        while a_idx < a_end:
+            a_j = a_indices[a_idx]
+            out_indices[out_idx] = a_j
+            out_data[out_idx] = op(a_data[a_idx], default_value)
+            a_idx += 1
+            out_idx += 1
+
+        while b_idx < b_end:
+            b_j = b_indices[b_idx]
+            out_indices[out_idx] = b_j
+            out_data[out_idx] = op(default_value, b_data[b_idx])
+            b_idx += 1
+            out_idx += 1
+
+        out_indptr[i + 1] = out_idx
+
+    out_indices = out_indices[: out_idx]
+    out_data = out_data[: out_idx]
+
+    return out_data, out_indices, out_indptr

--- a/sparse/_compressed/elemwise.py
+++ b/sparse/_compressed/elemwise.py
@@ -5,6 +5,8 @@ import numpy as np
 import scipy.sparse
 from numba import njit
 
+from .compressed import _Compressed2d
+
 
 def op_unary(func, a):
     res = a.copy()
@@ -19,7 +21,10 @@ def _numba_d(func):
 
 def binary_op(func, a, b):
     func = _numba_d(func)
-    return op_union_indices(func, a, b)
+    if isinstance(a, _Compressed2d) and isinstance(b, _Compressed2d):
+        return op_union_indices(func, a, b)
+    else:
+        raise NotImplementedError()
 
 
 def op_union_indices(

--- a/sparse/_umath.py
+++ b/sparse/_umath.py
@@ -411,7 +411,11 @@ def _resolve_result_type(args: "list[ArrayLike]") -> "Type":
     from ._compressed import GCXS, CSR, CSC
     from ._coo import COO
     from ._dok import DOK
+    from ._sparse_array import SparseArray
     from ._compressed.compressed import _Compressed2d
+
+    args = [arg for arg in args if isinstance(arg, SparseArray)]
+    print([type(arg) for arg in args])
 
     if all(isinstance(arg, DOK) for arg in args):
         out_type = DOK

--- a/sparse/_umath.py
+++ b/sparse/_umath.py
@@ -498,13 +498,14 @@ class _Elemwise:
 
     def get_result(self):
         from ._coo import COO
+        from ._sparse_array import SparseArray
         from ._compressed.compressed import _Compressed2d
 
         if self.args is None:
             return NotImplemented
 
         if self._dense_result:
-            args = [a.todense() if isinstance(a, COO) else a for a in self.args]
+            args = [a.todense() if isinstance(a, SparseArray) else a for a in self.args]
             return self.func(*args, **self.kwargs)
 
         if issubclass(self.out_type, _Compressed2d):
@@ -588,7 +589,6 @@ class _Elemwise:
         ValueError
             If the fill-value is inconsistent.
         """
-        from ._coo import COO
         from ._sparse_array import SparseArray
 
         zero_args = tuple(
@@ -609,7 +609,7 @@ class _Elemwise:
             fill_value = fill_value_array[(0,) * fill_value_array.ndim]
         except IndexError:
             zero_args = tuple(
-                arg.fill_value if isinstance(arg, COO) else _zero_of_dtype(arg.dtype)
+                arg.fill_value if isinstance(arg, SparseArray) else _zero_of_dtype(arg.dtype)
                 for arg in self.args
             )
             fill_value = self.func(*zero_args, **self.kwargs)[()]

--- a/sparse/_umath.py
+++ b/sparse/_umath.py
@@ -481,7 +481,7 @@ class _Elemwise:
         # Hmm, this may need major major changes.
         # Case to consider: CSR or CSC + 1d COO
         for arg in args:
-            if isinstance(arg, _Compressed2d):
+            if self.out_type != COO and isinstance(arg, _Compressed2d):
                 processed_args.append(arg)
             elif isscalar(arg) or isinstance(arg, np.ndarray):
                 # Faster and more reliable to pass ()-shaped ndarrays as scalars.

--- a/sparse/_umath.py
+++ b/sparse/_umath.py
@@ -405,6 +405,45 @@ def broadcast_to(x, shape):
     )
 
 
+# TODO: Figure out the right way to type this
+# TODO: Figure out how to do 1d COO + CSR or CSC
+def _resolve_result_type(args: "list[ArrayLike]") -> "Type":
+    from ._compressed import GCXS, CSR, CSC
+    from ._coo import COO
+    from ._dok import DOK
+    from ._compressed.compressed import _Compressed2d
+
+    if all(isinstance(arg, DOK) for arg in args):
+        out_type = DOK
+    elif all(isinstance(arg, CSR) for arg in args):
+        out_type = CSR
+    elif all(isinstance(arg, CSC) for arg in args):
+        out_type = CSC
+    elif all(isinstance(arg, _Compressed2d) for arg in args):
+        out_type = CSR
+    elif all(isinstance(arg, GCXS) for arg in args):
+        out_type = GCXS
+    else:
+        out_type = COO
+    return out_type
+
+
+def _from_scipy_sparse(a):
+    from ._compressed import CSR, CSC
+    from ._coo import COO
+    from ._dok import DOK
+
+    assert isinstance(a, scipy.sparse.spmatrix)
+    if isinstance(a, scipy.sparse.csr_matrix):
+        return CSR(a)
+    elif isinstance(a, scipy.sparse.csc_matrix):
+        return CSC(a)
+    elif isinstance(a, scipy.sparse.dok_matrix):
+        return DOK(a)
+    else:
+        return COO(a)
+
+
 class _Elemwise:
     def __init__(self, func, *args, **kwargs):
         """
@@ -421,24 +460,20 @@ class _Elemwise:
         """
         from ._coo import COO
         from ._sparse_array import SparseArray
-        from ._compressed import GCXS
+        from ._compressed import GCXS, CSR, CSC
+        from ._compressed.compressed import _Compressed2d
         from ._dok import DOK
 
         processed_args = []
-        out_type = GCXS
 
-        sparse_args = [arg for arg in args if isinstance(arg, SparseArray)]
-
-        if all(isinstance(arg, DOK) for arg in sparse_args):
-            out_type = DOK
-        elif all(isinstance(arg, GCXS) for arg in sparse_args):
-            out_type = GCXS
-        else:
-            out_type = COO
-
+        # Should this happen before dispatch?
+        # Hmm, this may need major major changes.
+        # Case to consider: CSR or CSC + 1d COO
         for arg in args:
             if isinstance(arg, scipy.sparse.spmatrix):
-                processed_args.append(COO.from_scipy_sparse(arg))
+                arg = _from_scipy_sparse(arg)
+            if isinstance(arg, _Compressed2d):
+                processed_args.append(arg)
             elif isscalar(arg) or isinstance(arg, np.ndarray):
                 # Faster and more reliable to pass ()-shaped ndarrays as scalars.
                 processed_args.append(np.asarray(arg))
@@ -450,7 +485,7 @@ class _Elemwise:
             else:
                 processed_args.append(arg)
 
-        self.out_type = out_type
+        self.out_type = _resolve_result_type(processed_args)
         self.args = tuple(processed_args)
         self.func = func
         self.dtype = kwargs.pop("dtype", None)
@@ -463,6 +498,7 @@ class _Elemwise:
 
     def get_result(self):
         from ._coo import COO
+        from ._compressed.compressed import _Compressed2d
 
         if self.args is None:
             return NotImplemented
@@ -470,6 +506,9 @@ class _Elemwise:
         if self._dense_result:
             args = [a.todense() if isinstance(a, COO) else a for a in self.args]
             return self.func(*args, **self.kwargs)
+
+        if issubclass(self.out_type, _Compressed2d):
+            return self._get_result_compressed_2d()
 
         if any(s == 0 for s in self.shape):
             data = np.empty((0,), dtype=self.fill_value.dtype)
@@ -516,6 +555,29 @@ class _Elemwise:
             has_duplicates=False,
             fill_value=self.fill_value,
         ).asformat(self.out_type)
+
+    def _get_result_compressed_2d(self):
+        from ._compressed import elemwise as elemwise2d
+        from ._compressed.compressed import _Compressed2d
+        if len(self.args) == 1:
+            result = elemwise2d.op_unary(self.func, self.args[0])
+
+        processed_args = []
+        for arg in self.args:
+            if isinstance(arg, self.out_type):
+                processed_args.append(arg)
+            elif isinstance(arg, _Compressed2d):
+                processed_args.append(self.out_type(arg))
+            elif isinstance(arg, np.ndarray):
+                processed_args.append(np.broadcast_to(arg, self.shape))
+            else:
+                raise NotImplementedError()
+
+        if len(processed_args) == 2:
+            result = elemwise2d.binary_op(self.func, *processed_args)
+
+        return result
+
 
     def _get_fill_value(self):
         """

--- a/sparse/_umath.py
+++ b/sparse/_umath.py
@@ -589,9 +589,10 @@ class _Elemwise:
             If the fill-value is inconsistent.
         """
         from ._coo import COO
+        from ._sparse_array import SparseArray
 
         zero_args = tuple(
-            arg.fill_value[...] if isinstance(arg, COO) else arg for arg in self.args
+            arg.fill_value[...] if isinstance(arg, SparseArray) else arg for arg in self.args
         )
 
         # Some elemwise functions require a dtype argument, some abhorr it.

--- a/sparse/tests/test_elemwise.py
+++ b/sparse/tests/test_elemwise.py
@@ -482,32 +482,6 @@ def test_leftside_elemwise_scalar(func, scalar, convert_to_np_number):
     assert_eq(fs, func(y, x))
 
 
-@pytest.mark.parametrize("func", [np.add, np.subtract, np.multiply])
-@pytest.mark.parametrize("type_a,type_b", [(CSR, CSR), (CSR, CSC), (CSR, np.asarray)])
-def test_2d_binary_op(func, type_a, type_b):
-    # TODO: implement COO.asformat(CSR)
-    from sparse import SparseArray
-
-    # Doing the ugly conditional since this errors from explicit conversion to dense
-    # There's gotta be a better way to do this
-    if type_a != np.asarray:
-        a = type_a(sparse.random((20, 10), density=0.5))
-    else:
-        a = sparse.random((20, 10), density=0.5).todense()
-    if type_b != np.asarray:
-        b = type_b(sparse.random((20, 10), density=0.5))
-    else:
-        b = sparse.random((20, 10), density=0.5).todense()
-
-    ref_a = a.todense() if isinstance(a, SparseArray) else a
-    ref_b = b.todense() if isinstance(b, SparseArray) else b
-
-    expected = func(ref_a, ref_b)
-    result = func(a, b)
-
-    assert_eq(expected, result)
-
-
 from itertools import product
 from functools import singledispatch
 
@@ -523,6 +497,7 @@ def _(x):
 def _(x):
     return x
 
+# TODO: Add test for result types
 @pytest.mark.parametrize("func", [np.add, np.subtract, np.multiply])
 @pytest.mark.parametrize(
     "a,b",

--- a/sparse/tests/test_elemwise.py
+++ b/sparse/tests/test_elemwise.py
@@ -5,6 +5,7 @@ import operator
 from sparse import COO, DOK
 from sparse._compressed import GCXS, CSR, CSC
 from sparse._utils import assert_eq, random_value_array
+from sparse import SparseArray
 
 
 @pytest.mark.parametrize(
@@ -508,7 +509,19 @@ def test_2d_binary_op(func, type_a, type_b):
 
 
 from itertools import product
+from functools import singledispatch
 
+@singledispatch
+def asdense(x):
+    raise NotImplementedError()
+
+@asdense.register(SparseArray)
+def _(x):
+    return x.todense()
+
+@asdense.register(np.ndarray)
+def _(x):
+    return x
 
 @pytest.mark.parametrize("func", [np.add, np.subtract, np.multiply])
 @pytest.mark.parametrize(
@@ -544,7 +557,7 @@ def test_2d_binary_op(func, a, b):
     expected = func(ref_a, ref_b)
     result = func(a, b)
 
-    assert_eq(expected, result)
+    assert_eq(expected, asdense(result))
 
 
 @pytest.mark.parametrize(

--- a/sparse/tests/test_elemwise.py
+++ b/sparse/tests/test_elemwise.py
@@ -524,7 +524,14 @@ def _(x):
 )
 def test_2d_binary_op(func, a, b):
     # TODO: implement COO.asformat(CSR)
+    def _is_ndarray_1d(x):
+        return isinstance(x, np.ndarray) and sum(s != 1 for s in x.shape) <= 1
+
     from sparse import SparseArray
+
+    if func in [np.add, np.subtract] and (_is_ndarray_1d(a) or _is_ndarray_1d(b)):
+        # https://github.com/pydata/sparse/issues/460
+        pytest.skip()
 
     ref_a = a.todense() if isinstance(a, SparseArray) else a
     ref_b = b.todense() if isinstance(b, SparseArray) else b


### PR DESCRIPTION
Very WIP draft PR for elemwise operations on CSR and CSC arrays. 

Currently just implements broadcasting operations between compressed 2d arrays. Cases that would be covered by a full implementation:

- [ ] Unary broadcasting (e.g. `-a`)
- [ ] Binary broadcasting
  - [x] compressed_2d + compressed_2d
  - [ ] compressed_2d + scalar
  - [ ] compressed_2d + dense_1d
  - [ ] compressed_2d + sparse_1d

------------------

A quick benchmark:

```python
import sparse
from sparse._compressed import CSR, CSC

gcxs_a = sparse.random((10000, 20000), .01, format="gcxs")
gcxs_b = sparse.random((10000, 20000), .01, format="gcxs")

csr_a = CSR(gcxs_a)
csr_b = CSR(gcxs_b)

scipy_a = a.to_scipy_sparse()
scipy_b = b.to_scipy_sparse()
```

```python
%timeit gcxs_a + gcxs_b
# 999 ms ± 10.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit csr_a + csr_b
# 32.2 ms ± 1.9 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit scipy_a + scipy_b
# 27.5 ms ± 894 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Should provide some insight for #460