### PR TITLE
Pytest failures - fixed with black re-formatting

### DIFF
--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -393,7 +393,7 @@ class DOK(SparseArray, NDArrayOperatorsMixin):
         )
 
     def _filter_by_key(self, coords, slice_key):
-        """Filter data coordinates to be within given slice """
+        """Filter data coordinates to be within given slice"""
         filter_arr = np.ones(coords.shape[0], dtype=bool)
         for coords_in_dim, sl in zip(coords.T, slice_key):
             filter_arr *= (

--- a/sparse/tests/test_coo_numba.py
+++ b/sparse/tests/test_coo_numba.py
@@ -7,14 +7,14 @@ import numpy as np
 
 @numba.njit
 def identity(x):
-    """ Pass an object through numba and back """
+    """Pass an object through numba and back"""
     return x
 
 
 def identity_constant(x):
     @numba.njit
     def get_it():
-        """ Pass an object through numba and back as a constant """
+        """Pass an object through numba and back as a constant"""
         return x
 
     return get_it()
@@ -34,7 +34,7 @@ def assert_coo_same_memory(c1, c2):
 
 
 class TestBasic:
-    """ Test very simple construction and field access """
+    """Test very simple construction and field access"""
 
     def test_roundtrip(self):
         c1 = sparse.COO(np.eye(3), fill_value=1)


### PR DESCRIPTION
This is super minor, but I noticed when I forked the repository (just to look at things), a couple of tests fail when you run `pytest --pyargs sparse` as described in the [contributing guide](https://github.com/pydata/sparse/blob/master/docs/contributing.rst).

The reason for the two test failures is some whitespace that the black formatting tool doesn't like. So it's nothing important, but it's always nice to have things work smoothly when new people go through the contributing guide. 