### PR TITLE
Skip doctest on 32bits arch

### DIFF
--- a/sparse/tests/conftest.py
+++ b/sparse/tests/conftest.py
@@ -2,6 +2,5 @@ import platform
 import numpy.distutils.system_info as sysinfo
 
 def pytest_cmdline_preparse(args):
-    if platform.system() != "Windows":
-        if sysinfo.platform_bits != 32:
-            args.append("--doctest-modules")
+    if platform.system() != "Windows" or sysinfo.platform_bits != 32:
+        args.append("--doctest-modules")

--- a/sparse/tests/conftest.py
+++ b/sparse/tests/conftest.py
@@ -2,5 +2,5 @@ import platform
 import numpy.distutils.system_info as sysinfo
 
 def pytest_cmdline_preparse(args):
-    if platform.system() != "Windows" or sysinfo.platform_bits != 32:
+    if platform.system() != "Windows" and sysinfo.platform_bits != 32:
         args.append("--doctest-modules")

--- a/sparse/tests/conftest.py
+++ b/sparse/tests/conftest.py
@@ -1,6 +1,7 @@
 import platform
 import numpy.distutils.system_info as sysinfo
 
+
 def pytest_cmdline_preparse(args):
     if platform.system() != "Windows" and sysinfo.platform_bits != 32:
         args.append("--doctest-modules")

--- a/sparse/tests/conftest.py
+++ b/sparse/tests/conftest.py
@@ -1,6 +1,7 @@
 import platform
-
+import numpy.distutils.system_info as sysinfo
 
 def pytest_cmdline_preparse(args):
     if platform.system() != "Windows":
-        args.append("--doctest-modules")
+        if sysinfo.platform_bits != 32:
+            args.append("--doctest-modules")


### PR DESCRIPTION
Disable doctest on 32bits architectures because they generate innocent errors.

See https://github.com/pydata/sparse/issues/428#issuecomment-771893752 and https://bugs.debian.org/988424

Now, during a build on a 32bits system, we have other errors:
```

=================================== FAILURES ===================================
___________________________ TestBasic.test_roundtrip ___________________________

self = <test_coo_numba.TestBasic object at 0xed466400>

    def test_roundtrip(self):
        c1 = sparse.COO(np.eye(3), fill_value=1)
>       c2 = identity(c1)

tests/test_coo_numba.py:41: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3/dist-packages/numba/core/dispatcher.py:414: in _compile_for_args
    error_rewrite(e, 'typing')
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

e = TypingError('Failed in nopython mode pipeline (step: nopython frontend)\nnon-precise type pyobject\nDuring: typing of ...caused by the following argument(s):\n- argument 0: Cannot determine Numba type of <class \'sparse._coo.core.COO\'>\n')
issue_type = 'typing'

    def error_rewrite(e, issue_type):
        """
        Rewrite and raise Exception `e` with help supplied based on the
        specified issue_type.
        """
        if config.SHOW_HELP:
            help_msg = errors.error_extras[issue_type]
            e.patch_message('\n'.join((str(e).rstrip(), help_msg)))
        if config.FULL_TRACEBACKS:
            raise e
        else:
>           raise e.with_traceback(None)
E           numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
E           non-precise type pyobject
E           During: typing of argument at /build/python-sparse-0.11.2/.pybuild/cpython3_3.9_sparse/build/tests/test_coo_numba.py (11)
E           
E           File "tests/test_coo_numba.py", line 11:
E           def identity(x):
E               <source elided>
E               """ Pass an object through numba and back """
E               return x
E               ^
E           
E           This error may have been caused by the following argument(s):
E           - argument 0: Cannot determine Numba type of <class 'sparse._coo.core.COO'>

/usr/lib/python3/dist-packages/numba/core/dispatcher.py:357: TypingError
______________________ TestBasic.test_roundtrip_constant _______________________

self = <test_coo_numba.TestBasic object at 0xed2c8208>

    def test_roundtrip_constant(self):
        c1 = sparse.COO(np.eye(3), fill_value=1)
>       c2 = identity_constant(c1)

tests/test_coo_numba.py:47: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/test_coo_numba.py:20: in identity_constant
    return get_it()
/usr/lib/python3/dist-packages/numba/core/dispatcher.py:414: in _compile_for_args
    error_rewrite(e, 'typing')
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

e = TypingError('Failed in nopython mode pipeline (step: nopython frontend)\nUntyped global name \'x\': Cannot determine N...  <source elided>\n        """ Pass an object through numba and back as a constant """\n        return x\n        ^\n')
issue_type = 'typing'

    def error_rewrite(e, issue_type):
        """
        Rewrite and raise Exception `e` with help supplied based on the
        specified issue_type.
        """
        if config.SHOW_HELP:
            help_msg = errors.error_extras[issue_type]
            e.patch_message('\n'.join((str(e).rstrip(), help_msg)))
        if config.FULL_TRACEBACKS:
            raise e
        else:
>           raise e.with_traceback(None)
E           numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
E           Untyped global name 'x': Cannot determine Numba type of <class 'sparse._coo.core.COO'>
E           
E           File "tests/test_coo_numba.py", line 18:
E               def get_it():
E                   <source elided>
E                   """ Pass an object through numba and back as a constant """
E                   return x
E                   ^

/usr/lib/python3/dist-packages/numba/core/dispatcher.py:357: TypingError
_________________________ TestBasic.test_unpack_attrs __________________________

self = <test_coo_numba.TestBasic object at 0xebaf3b98>

    def test_unpack_attrs(self):
        @numba.njit
        def unpack(c):
            return c.coords, c.data, c.shape, c.fill_value
    
        c1 = sparse.COO(np.eye(3), fill_value=1)
>       coords, data, shape, fill_value = unpack(c1)

tests/test_coo_numba.py:57: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3/dist-packages/numba/core/dispatcher.py:414: in _compile_for_args
    error_rewrite(e, 'typing')
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

e = TypingError('Failed in nopython mode pipeline (step: nopython frontend)\nnon-precise type pyobject\nDuring: typing of ...caused by the following argument(s):\n- argument 0: Cannot determine Numba type of <class \'sparse._coo.core.COO\'>\n')
issue_type = 'typing'

    def error_rewrite(e, issue_type):
        """
        Rewrite and raise Exception `e` with help supplied based on the
        specified issue_type.
        """
        if config.SHOW_HELP:
            help_msg = errors.error_extras[issue_type]
            e.patch_message('\n'.join((str(e).rstrip(), help_msg)))
        if config.FULL_TRACEBACKS:
            raise e
        else:
>           raise e.with_traceback(None)
E           numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
E           non-precise type pyobject
E           During: typing of argument at /build/python-sparse-0.11.2/.pybuild/cpython3_3.9_sparse/build/tests/test_coo_numba.py (54)
E           
E           File "tests/test_coo_numba.py", line 54:
E                   def unpack(c):
E                       return c.coords, c.data, c.shape, c.fill_value
E                       ^
E           
E           This error may have been caused by the following argument(s):
E           - argument 0: Cannot determine Numba type of <class 'sparse._coo.core.COO'>

/usr/lib/python3/dist-packages/numba/core/dispatcher.py:357: TypingError
_________________________ TestBasic.test_repack_attrs __________________________

self = <test_coo_numba.TestBasic object at 0xec216208>

    def test_repack_attrs(self):
        @numba.njit
        def pack(coords, data, shape):
            return sparse.COO(coords, data, shape)
    
        # repacking fill_value isn't possible yet
        c1 = sparse.COO(np.eye(3))
>       c2 = pack(c1.coords, c1.data, c1.shape)

tests/test_coo_numba.py:68: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3/dist-packages/numba/core/dispatcher.py:414: in _compile_for_args
    error_rewrite(e, 'typing')
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

e = TypingError('Failed in nopython mode pipeline (step: nopython frontend)\nUnknown attribute \'COO\' of type Module(<mod...line 64:\n        def pack(coords, data, shape):\n            return sparse.COO(coords, data, shape)\n            ^\n')
issue_type = 'typing'

    def error_rewrite(e, issue_type):
        """
        Rewrite and raise Exception `e` with help supplied based on the
        specified issue_type.
        """
        if config.SHOW_HELP:
            help_msg = errors.error_extras[issue_type]
            e.patch_message('\n'.join((str(e).rstrip(), help_msg)))
        if config.FULL_TRACEBACKS:
            raise e
        else:
>           raise e.with_traceback(None)
E           numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
E           Unknown attribute 'COO' of type Module(<module 'sparse' from '/build/python-sparse-0.11.2/.pybuild/cpython3_3.9_sparse/build/sparse/__init__.py'>)
E           
E           File "tests/test_coo_numba.py", line 64:
E                   def pack(coords, data, shape):
E                       return sparse.COO(coords, data, shape)
E                       ^
E           
E           During: typing of get attribute at /build/python-sparse-0.11.2/.pybuild/cpython3_3.9_sparse/build/tests/test_coo_numba.py (64)
E           
E           File "tests/test_coo_numba.py", line 64:
E                   def pack(coords, data, shape):
E                       return sparse.COO(coords, data, shape)
E                       ^

/usr/lib/python3/dist-packages/numba/core/dispatcher.py:357: TypingError
=========================== short test summary info ============================
FAILED tests/test_coo_numba.py::TestBasic::test_roundtrip - numba.core.errors...
FAILED tests/test_coo_numba.py::TestBasic::test_roundtrip_constant - numba.co...
FAILED tests/test_coo_numba.py::TestBasic::test_unpack_attrs - numba.core.err...
FAILED tests/test_coo_numba.py::TestBasic::test_repack_attrs - numba.core.err...
=========== 4 failed, 4307 passed, 31 xfailed, 34 xpassed in 37.26s ============

```