### PR TITLE
fix scipy url in intersphinx mapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,7 +185,7 @@ texinfo_documents = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://docs.scipy.org/doc/numpy/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
 }
 
 extlinks = {


### PR DESCRIPTION
Links in documentation pointing to the scipy API docs are currently broken. This fixes issue #542 to point to the correct scipy API urls
