### PR TITLE
Relative imports (helps vendoring)

### DIFF
--- a/sparse/_common.py
+++ b/sparse/_common.py
@@ -1323,7 +1323,7 @@ def eye(N, M=None, k=0, dtype=float, format="coo", **kwargs):
            [0., 0., 1.],
            [0., 0., 0.]])
     """
-    from sparse import COO
+    from ._coo import COO
 
     if M is None:
         M = N
@@ -1595,7 +1595,8 @@ def outer(a, b, out=None):
            [0, 2, 4, 6],
            [0, 3, 6, 9]])
     """
-    from sparse import SparseArray, COO
+    from ._sparse_array import SparseArray
+    from ._coo import COO
 
     if isinstance(a, SparseArray):
         a = COO(a)

--- a/sparse/_compressed/compressed.py
+++ b/sparse/_compressed/compressed.py
@@ -522,7 +522,7 @@ class GCXS(SparseArray, NDArrayOperatorsMixin):
         NotImplementedError
             If the format isn't supported.
         """
-        from sparse._utils import convert_format
+        from .._utils import convert_format
 
         format = convert_format(format)
         ret = None

--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -1437,7 +1437,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         NotImplementedError
             If the format isn't supported.
         """
-        from sparse._utils import convert_format
+        from .._utils import convert_format
 
         format = convert_format(format)
 

--- a/sparse/_coo/numba_extension.py
+++ b/sparse/_coo/numba_extension.py
@@ -17,7 +17,7 @@ from numba.extending import (
 from numba.core.imputils import impl_ret_borrowed, lower_constant, lower_builtin
 from numba.core.typing.typeof import typeof_impl
 from numba.core import cgutils, types
-from sparse._utils import _zero_of_dtype
+from .._utils import _zero_of_dtype
 import contextlib
 
 from . import COO

--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -508,7 +508,7 @@ class DOK(SparseArray, NDArrayOperatorsMixin):
         NotImplementedError
             If the format isn't supported.
         """
-        from sparse._utils import convert_format
+        from ._utils import convert_format
 
         format = convert_format(format)
 

--- a/sparse/_numba_extension.py
+++ b/sparse/_numba_extension.py
@@ -3,4 +3,4 @@ def _init_extension():
     Load extensions when numba is loaded.
     This name must match the one in setup.py
     """
-    import sparse._coo.numba_extension
+    from ._coo import numba_extension


### PR DESCRIPTION
Use relative imports, apart from being a good code style it makes vendoring sparse within another package easier.