### PR TITLE
Explicitly wrap fill_value #566

### DIFF
--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -257,7 +257,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         if isinstance(shape, np.ndarray):
             shape = tuple(shape)
 
-        if shape is not None and not self.coords.size:
+        if shape and not self.coords.size:
             warnings.warn(
                 "coords should be an ndarray. This will raise a ValueError in the future.",
                 DeprecationWarning,

--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -257,7 +257,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         if isinstance(shape, np.ndarray):
             shape = tuple(shape)
 
-        if shape and not self.coords.size:
+        if shape is not None and not self.coords.size:
             warnings.warn(
                 "coords should be an ndarray. This will raise a ValueError in the future.",
                 DeprecationWarning,

--- a/sparse/_umath.py
+++ b/sparse/_umath.py
@@ -533,7 +533,8 @@ class _Elemwise:
         from ._coo import COO
 
         zero_args = tuple(
-            arg.fill_value[...] if isinstance(arg, COO) else arg for arg in self.args
+            np.array(arg.fill_value) if isinstance(arg, COO) else arg
+            for arg in self.args
         )
 
         # Some elemwise functions require a dtype argument, some abhorr it.


### PR DESCRIPTION
Explicitly wrap fill_value in array instead of assuming a numpy dtype, should address #566