### PR TITLE
fix errors/crashes in multi-dimensional slicing

### DIFF
--- a/sparse/_compressed/convert.py
+++ b/sparse/_compressed/convert.py
@@ -35,11 +35,11 @@ def compute_flat(increments, cols, operations):  # pragma: no cover
     positions = np.zeros(len(increments) - 1, dtype=np.intp)
     pos = len(increments) - 2
     for i in range(operations):
-        if i != 0 and positions[pos] == increments[pos].shape[0]:
+        while i != 0 and positions[pos] == increments[pos].shape[0]:
             positions[pos] = 0
             pos -= 1
             positions[pos] += 1
-            pos += 1
+        pos = len(increments) - 2
         to_add = np.array(
             [increments[i][positions[i]] for i in range(len(increments) - 1)]
         ).sum()

--- a/sparse/tests/test_compressed_convert.py
+++ b/sparse/tests/test_compressed_convert.py
@@ -57,4 +57,6 @@ def test_compute_flat(shape, expected_subsample, subsample):
     ],
 )
 def test_transform_shape(shape, expected_shape):
-    assert_eq(convert.transform_shape(np.asarray(shape)), expected_shape)
+    assert_eq(
+        convert.transform_shape(np.asarray(shape)), expected_shape, compare_dtype=False
+    )

--- a/sparse/tests/test_compressed_convert.py
+++ b/sparse/tests/test_compressed_convert.py
@@ -29,14 +29,13 @@ def make_increments(shape):
 )
 def test_compute_flat(shape, expected_subsample, subsample):
     increments = make_increments(shape)
-    operations = np.prod(
-        [inc.shape[0] for inc in increments[:-1]], dtype=increments[0].dtype
-    )
-    cols = np.empty(increments[-1].size * operations, dtype=increments[0].dtype)
+    dtype = increments[0].dtype
+    operations = np.prod([inc.shape[0] for inc in increments[:-1]], dtype=dtype)
+    cols = np.empty(increments[-1].size * operations, dtype=dtype)
 
     assert_eq(
         convert.compute_flat(increments, cols, operations)[::subsample],
-        expected_subsample,
+        expected_subsample.astype(dtype),
     )
 
 

--- a/sparse/tests/test_compressed_convert.py
+++ b/sparse/tests/test_compressed_convert.py
@@ -1,0 +1,39 @@
+import sparse
+import pytest
+import numpy as np
+
+import sparse._compressed.convert as convert
+from sparse._utils import assert_eq
+
+
+# @pytest.mark.parametrize(
+# )
+def test_convert_to_flat():
+    ...
+
+
+# @pytest.mark.parametrize(
+# )
+def test_compute_flat():
+    ...
+    # assert_eq(x[index], s[index])
+
+
+@pytest.mark.parametrize(
+    "shape, expected_shape",
+    [
+        [(13, 12, 12, 9, 7), np.array([9072, 756, 63, 7, 1])],
+        [(12, 15, 7, 14, 9), np.array([13230, 882, 126, 9, 1])],
+        [
+            (18, 5, 12, 14, 9, 11, 8, 14),
+            np.array([9313920, 1862784, 155232, 11088, 1232, 112, 14, 1]),
+        ],
+        [
+            (11, 6, 13, 11, 17, 7, 15),
+            np.array([1531530, 255255, 19635, 1785, 105, 15, 1]),
+        ],
+        [(9, 9, 12, 7, 12), np.array([9072, 1008, 84, 12, 1])],
+    ],
+)
+def test_transform_shape(shape, expected_shape):
+    assert_eq(convert.transform_shape(np.asarray(shape)), expected_shape)

--- a/sparse/tests/test_compressed_convert.py
+++ b/sparse/tests/test_compressed_convert.py
@@ -1,27 +1,62 @@
 import sparse
 import pytest
 import numpy as np
+from numba.typed import List
 
 import sparse._compressed.convert as convert
 from sparse._utils import assert_eq
 
 
-# @pytest.mark.parametrize(
-# )
-def test_convert_to_flat():
-    ...
+def make_increments(shape):
+    inds = [np.arange(1, a // 2) for a in shape]
+    shape_bins = convert.transform_shape(np.asarray(shape))
+    increments = List([inds[i] * shape_bins[i] for i in range(len(shape))])
+    return increments
 
 
-# @pytest.mark.parametrize(
-# )
-def test_compute_flat():
-    ...
-    # assert_eq(x[index], s[index])
+@pytest.mark.parametrize(
+    "shape, expected_p100",
+    [
+        [(5, 6, 7, 8, 9), np.array([3610])],
+        [
+            (13, 12, 12, 9, 7),
+            np.array([9899, 12244, 19923, 28043, 30388, 38067, 46187, 48532]),
+        ],
+        [
+            (12, 15, 7, 14, 9),
+            np.array(
+                [
+                    14248,
+                    16166,
+                    18786,
+                    29278,
+                    31898,
+                    41754,
+                    44380,
+                    54866,
+                    57486,
+                    68050,
+                    69968,
+                ]
+            ),
+        ],
+        [(9, 9, 12, 7, 12), np.array([10177, 12193, 20257, 28321, 30337])],
+    ],
+)
+def test_compute_flat(shape, expected_p100):
+    increments = make_increments(shape)
+    operations = np.prod(
+        [inc.shape[0] for inc in increments[:-1]], dtype=increments[0].dtype
+    )
+    cols = np.empty(increments[-1].size * operations, dtype=increments[0].dtype)
+
+    assert_eq(convert.compute_flat(increments, cols, operations)[::100], expected_p100)
 
 
 @pytest.mark.parametrize(
     "shape, expected_shape",
     [
+        [(5, 6, 7, 8, 9), np.array([3024, 504, 72, 9, 1])],
         [(13, 12, 12, 9, 7), np.array([9072, 756, 63, 7, 1])],
         [(12, 15, 7, 14, 9), np.array([13230, 882, 126, 9, 1])],
         [


### PR DESCRIPTION
Possibly closes #550. Needs some review as I did not fully grok what `compute_flat` was doing here, but it seemed like it was failing to account for multi-dimensional sparse arrays properly.

There might be a better way to do this (or a better way to calculate this more generally, I'm not sure) but this seems to have fixed the problem identified in #550 as well as some crashes I observed in particularly bad situations.