### PR TITLE
Improving indexing performance

### DIFF
--- a/sparse/_compressed/convert.py
+++ b/sparse/_compressed/convert.py
@@ -35,11 +35,11 @@ def compute_flat(increments, cols, operations):  # pragma: no cover
     positions = np.zeros(len(increments) - 1, dtype=np.intp)
     pos = len(increments) - 2
     for i in range(operations):
-        if i != 0 and positions[pos] == increments[pos].shape[0]:
+        while i != 0 and positions[pos] == increments[pos].shape[0]:
             positions[pos] = 0
             pos -= 1
             positions[pos] += 1
-            pos += 1
+        pos = len(increments) - 2
         to_add = np.array(
             [increments[i][positions[i]] for i in range(len(increments) - 1)]
         ).sum()

--- a/sparse/_compressed/convert.py
+++ b/sparse/_compressed/convert.py
@@ -40,9 +40,11 @@ def compute_flat(increments, cols, operations):  # pragma: no cover
             pos -= 1
             positions[pos] += 1
         pos = len(increments) - 2
-        to_add = np.array(
-            [increments[i][positions[i]] for i in range(len(increments) - 1)]
-        ).sum()
+
+        to_add = 0
+        for i in range(len(increments) - 1):
+            to_add += increments[i][positions[i]]
+
         cols[start:end] = increments[-1] + to_add
         if pos != -1:
             positions[pos] += 1
@@ -60,7 +62,7 @@ def transform_shape(shape):  # pragma: no cover
     """
     shape_bins = np.empty(len(shape), dtype=np.intp)
     shape_bins[-1] = 1
-    for i in range(len(shape) - 2, -1, -1):
+    for i in range(len(shape) - 1):
         shape_bins[i] = np.prod(shape[i + 1 :])
     return shape_bins
 

--- a/sparse/_compressed/convert.py
+++ b/sparse/_compressed/convert.py
@@ -7,20 +7,28 @@ from functools import reduce
 from numba.typed import List
 
 
+@numba.jit(nopython=True, nogil=True)
 def convert_to_flat(inds, shape, dtype):
     """
     Converts the indices of either the compressed or uncompressed axes
     into a linearized form. Prepares the inputs for compute_flat.
     """
-    inds = [np.array(ind) for ind in inds]
-    if any(ind.ndim > 1 for ind in inds):
-        raise IndexError("Only one-dimensional iterable indices supported.")
-    cols = np.empty(np.prod([ind.size for ind in inds]), dtype=dtype)
     shape_bins = transform_shape(np.asarray(shape))
     increments = List()
     for i in range(len(inds)):
         increments.append((inds[i] * shape_bins[i]).astype(dtype))
-    operations = np.prod([ind.shape[0] for ind in increments[:-1]], dtype=dtype)
+
+    operations = 1
+    for inc in increments[:-1]:
+        operations *= inc.shape[0]
+
+    if operations == 0:
+        return np.empty(0, dtype=dtype)
+
+    cols = increments[-1].repeat(operations).reshape((-1, operations)).T.flatten()
+    if len(increments) == 1:
+        return cols
+
     return compute_flat(increments, cols, operations)
 
 
@@ -35,21 +43,21 @@ def compute_flat(increments, cols, operations):  # pragma: no cover
     positions = np.zeros(len(increments) - 1, dtype=np.intp)
     pos = len(increments) - 2
     for i in range(operations):
-        while i != 0 and positions[pos] == increments[pos].shape[0]:
-            positions[pos] = 0
-            pos -= 1
-            positions[pos] += 1
-        pos = len(increments) - 2
-
         to_add = 0
-        for i in range(len(increments) - 1):
-            to_add += increments[i][positions[i]]
+        for j in range(len(increments) - 1):
+            to_add += increments[j][positions[j]]
 
-        cols[start:end] = increments[-1] + to_add
-        if pos != -1:
-            positions[pos] += 1
+        cols[start:end] += to_add
         start += increments[-1].shape[0]
         end += increments[-1].shape[0]
+
+        for j in range(pos, -1, -1):
+            positions[j] += 1
+            if positions[j] == increments[j].shape[0]:
+                positions[j] = 0
+            else:
+                break
+
     return cols
 
 

--- a/sparse/_compressed/indexing.py
+++ b/sparse/_compressed/indexing.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numba
+from numba.typed import List
 from numbers import Integral
 from itertools import zip_longest
 from collections.abc import Iterable
@@ -80,10 +81,13 @@ def getitem(x, key):
     # convert all ints and slices to iterables before flattening
     for i, ind in enumerate(reordered_key):
         if isinstance(ind, Integral):
-            reordered_key[i] = [ind]
+            reordered_key[i] = np.array([ind])
         elif isinstance(ind, slice):
             reordered_key[i] = np.arange(ind.start, ind.stop, ind.step)
+        elif isinstance(ind, np.ndarray) and ind.ndim > 1:
+            raise IndexError("Only one-dimensional iterable indices supported.")
 
+    reordered_key = List(reordered_key)
     shape = np.array(shape)
 
     # convert all indices of compressed axes to a single array index

--- a/sparse/_compressed/indexing.py
+++ b/sparse/_compressed/indexing.py
@@ -87,6 +87,8 @@ def getitem(x, key):
         elif isinstance(ind, np.ndarray) and ind.ndim > 1:
             raise IndexError("Only one-dimensional iterable indices supported.")
 
+        reordered_key[i] = reordered_key[i].astype(x.indices.dtype, copy=True)
+
     reordered_key = List(reordered_key)
     shape = np.array(shape)
 

--- a/sparse/_compressed/indexing.py
+++ b/sparse/_compressed/indexing.py
@@ -87,7 +87,7 @@ def getitem(x, key):
         elif isinstance(ind, np.ndarray) and ind.ndim > 1:
             raise IndexError("Only one-dimensional iterable indices supported.")
 
-        reordered_key[i] = reordered_key[i].astype(x.indices.dtype, copy=True)
+        reordered_key[i] = reordered_key[i].astype(x.indices.dtype, copy=False)
 
     reordered_key = List(reordered_key)
     shape = np.array(shape)

--- a/sparse/tests/test_compressed_convert.py
+++ b/sparse/tests/test_compressed_convert.py
@@ -57,4 +57,6 @@ def test_compute_flat(shape, expected_subsample, subsample):
     ],
 )
 def test_transform_shape(shape, expected_shape):
-    assert_eq(convert.transform_shape(np.asarray(shape)), expected_shape)
+    assert_eq(
+        convert.transform_shape(np.asarray(shape)), expected_shape, compare_dtype=False
+    )

--- a/sparse/tests/test_compressed_convert.py
+++ b/sparse/tests/test_compressed_convert.py
@@ -29,14 +29,13 @@ def make_increments(shape):
 )
 def test_compute_flat(shape, expected_subsample, subsample):
     increments = make_increments(shape)
-    operations = np.prod(
-        [inc.shape[0] for inc in increments[:-1]], dtype=increments[0].dtype
-    )
-    cols = np.empty(increments[-1].size * operations, dtype=increments[0].dtype)
+    dtype = increments[0].dtype
+    operations = np.prod([inc.shape[0] for inc in increments[:-1]], dtype=dtype)
+    cols = np.empty(increments[-1].size * operations, dtype=dtype)
 
     assert_eq(
         convert.compute_flat(increments, cols, operations)[::subsample],
-        expected_subsample,
+        expected_subsample.astype(dtype),
     )
 
 

--- a/sparse/tests/test_compressed_convert.py
+++ b/sparse/tests/test_compressed_convert.py
@@ -1,0 +1,39 @@
+import sparse
+import pytest
+import numpy as np
+
+import sparse._compressed.convert as convert
+from sparse._utils import assert_eq
+
+
+# @pytest.mark.parametrize(
+# )
+def test_convert_to_flat():
+    ...
+
+
+# @pytest.mark.parametrize(
+# )
+def test_compute_flat():
+    ...
+    # assert_eq(x[index], s[index])
+
+
+@pytest.mark.parametrize(
+    "shape, expected_shape",
+    [
+        [(13, 12, 12, 9, 7), np.array([9072, 756, 63, 7, 1])],
+        [(12, 15, 7, 14, 9), np.array([13230, 882, 126, 9, 1])],
+        [
+            (18, 5, 12, 14, 9, 11, 8, 14),
+            np.array([9313920, 1862784, 155232, 11088, 1232, 112, 14, 1]),
+        ],
+        [
+            (11, 6, 13, 11, 17, 7, 15),
+            np.array([1531530, 255255, 19635, 1785, 105, 15, 1]),
+        ],
+        [(9, 9, 12, 7, 12), np.array([9072, 1008, 84, 12, 1])],
+    ],
+)
+def test_transform_shape(shape, expected_shape):
+    assert_eq(convert.transform_shape(np.asarray(shape)), expected_shape)

--- a/sparse/tests/test_compressed_convert.py
+++ b/sparse/tests/test_compressed_convert.py
@@ -1,27 +1,62 @@
 import sparse
 import pytest
 import numpy as np
+from numba.typed import List
 
 import sparse._compressed.convert as convert
 from sparse._utils import assert_eq
 
 
-# @pytest.mark.parametrize(
-# )
-def test_convert_to_flat():
-    ...
+def make_increments(shape):
+    inds = [np.arange(1, a // 2) for a in shape]
+    shape_bins = convert.transform_shape(np.asarray(shape))
+    increments = List([inds[i] * shape_bins[i] for i in range(len(shape))])
+    return increments
 
 
-# @pytest.mark.parametrize(
-# )
-def test_compute_flat():
-    ...
-    # assert_eq(x[index], s[index])
+@pytest.mark.parametrize(
+    "shape, expected_p100",
+    [
+        [(5, 6, 7, 8, 9), np.array([3610])],
+        [
+            (13, 12, 12, 9, 7),
+            np.array([9899, 12244, 19923, 28043, 30388, 38067, 46187, 48532]),
+        ],
+        [
+            (12, 15, 7, 14, 9),
+            np.array(
+                [
+                    14248,
+                    16166,
+                    18786,
+                    29278,
+                    31898,
+                    41754,
+                    44380,
+                    54866,
+                    57486,
+                    68050,
+                    69968,
+                ]
+            ),
+        ],
+        [(9, 9, 12, 7, 12), np.array([10177, 12193, 20257, 28321, 30337])],
+    ],
+)
+def test_compute_flat(shape, expected_p100):
+    increments = make_increments(shape)
+    operations = np.prod(
+        [inc.shape[0] for inc in increments[:-1]], dtype=increments[0].dtype
+    )
+    cols = np.empty(increments[-1].size * operations, dtype=increments[0].dtype)
+
+    assert_eq(convert.compute_flat(increments, cols, operations)[::100], expected_p100)
 
 
 @pytest.mark.parametrize(
     "shape, expected_shape",
     [
+        [(5, 6, 7, 8, 9), np.array([3024, 504, 72, 9, 1])],
         [(13, 12, 12, 9, 7), np.array([9072, 756, 63, 7, 1])],
         [(12, 15, 7, 14, 9), np.array([13230, 882, 126, 9, 1])],
         [

--- a/sparse/tests/test_compressed_convert.py
+++ b/sparse/tests/test_compressed_convert.py
@@ -7,11 +7,38 @@ import sparse._compressed.convert as convert
 from sparse._utils import assert_eq
 
 
+def make_inds(shape):
+    return [np.arange(1, a - 1) for a in shape]
+
+
 def make_increments(shape):
-    inds = [np.arange(1, a - 1) for a in shape]
+    inds = make_inds(shape)
     shape_bins = convert.transform_shape(np.asarray(shape))
     increments = List([inds[i] * shape_bins[i] for i in range(len(shape))])
     return increments
+
+
+@pytest.mark.parametrize(
+    "shape, expected_subsample, subsample",
+    [
+        [(5, 6, 7, 8, 9), np.array([3610, 6892, 10338]), 1000],
+        [(13, 12, 12, 9, 7), np.array([9899, 34441, 60635, 86703]), 10000],
+        [
+            (12, 15, 7, 14, 9),
+            np.array([14248, 36806, 61382, 85956, 110532, 135106]),
+            10000,
+        ],
+        [(9, 9, 12, 7, 12), np.array([10177, 34369, 60577]), 10000],
+    ],
+)
+def test_convert_to_flat(shape, expected_subsample, subsample):
+    inds = make_inds(shape)
+    dtype = inds[0].dtype
+
+    assert_eq(
+        convert.convert_to_flat(inds, shape, dtype)[::subsample],
+        expected_subsample.astype(dtype),
+    )
 
 
 @pytest.mark.parametrize(

--- a/sparse/tests/test_compressed_convert.py
+++ b/sparse/tests/test_compressed_convert.py
@@ -31,7 +31,7 @@ def test_compute_flat(shape, expected_subsample, subsample):
     increments = make_increments(shape)
     dtype = increments[0].dtype
     operations = np.prod([inc.shape[0] for inc in increments[:-1]], dtype=dtype)
-    cols = np.empty(increments[-1].size * operations, dtype=dtype)
+    cols = np.tile(increments[-1], operations)
 
     assert_eq(
         convert.compute_flat(increments, cols, operations)[::subsample],


### PR DESCRIPTION
While working on #569*, I realized that there were a few optimizations that could be performed, and with a little additional work I could use `numba.jit` on `_compressed.convert.convert_to_flat` as well.

\* that PR should be merged first, as this builds on it

Short summary of changes:
 * removed an array allocation and let numba optimize a loop in `compute_flat`, which was roughly half the time in that function.
 * similarly, removed an array allocation and the use of `np.prod` and let numba take care of it
 * part of the work of building `cols` can be performed up front with the equivalent of `np.tile` (but that's not a numba-compatible function so this is the equivalent). This required changing my tests a little.
 * simplified `transform_shape` a little bit--no reason to iterate backwards
 * to maintain correctness I had to add a few checks earlier in the process, but I believe all tests pass

<details>
<summary>Code for some rudimentary A/B tests (using some random shapes and simple slices)</summary>

```python
import numpy as np
from numba.typed import List
from sparse._compressed.convert import convert_to_flat

random_shapes = [
    (5, 6, 7, 8, 9),
    (13, 12, 12, 9, 7),
    (12, 15, 7, 14, 9),
    (18, 5, 12, 14, 9, 11, 8, 14),
    (11, 6, 13, 11, 17, 7, 15),
    (9, 9, 12, 7, 12)
]

# call once to compile function
_ = convert_to_flat(
    List([np.arange(1, a - 1, dtype=int) for a in random_shapes[0]]),
    random_shapes[0],
    np.int64
)

# unoptimized version (from #569)
for shape in random_shapes:
    inds = List([np.arange(1, a - 1, dtype=int) for a in shape])
    %timeit convert_to_flat(inds, shape, np.int64)

257 µs ± 12.2 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
2.81 ms ± 183 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
2.8 ms ± 97.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
994 ms ± 25.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
113 ms ± 3.83 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
1.07 ms ± 6.8 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

# this version
for shape in random_shapes:
    inds = List([np.arange(1, a - 1, dtype=int) for a in shape])
    %timeit convert_to_flat(inds, shape, np.int64)

75.6 µs ± 1.26 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
1.42 ms ± 92.8 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
1.38 ms ± 20.8 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
677 ms ± 14.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
65 ms ± 2.63 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
458 µs ± 16.1 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

```

</details>