### PR TITLE
Add .format support to GCXS and COO classes

### DIFF
--- a/sparse/_compressed/compressed.py
+++ b/sparse/_compressed/compressed.py
@@ -278,6 +278,28 @@ class GCXS(SparseArray, NDArrayOperatorsMixin):
         return self.data.shape[0]
 
     @property
+    def format(self):
+        """
+        The storage format of this array.
+        Returns
+        -------
+        str
+            The storage format of this array.
+        See Also
+        -------
+        COO.format : Equivalent :obj:`COO` array property.
+        GCXS.format : Equivalent :obj:`GCXS` array property.
+        scipy.sparse.dok_matrix.format : The Scipy equivalent property.
+        Examples
+        -------
+        >>> import sparse
+        >>> s = sparse.random((5,5), density=0.2, format='gcxs')
+        >>> s.format
+        'gcxs'
+        """
+        return "gcxs"
+
+    @property
     def nbytes(self):
         """
         The number of bytes taken up by this object. Note that for small arrays,

--- a/sparse/_compressed/compressed.py
+++ b/sparse/_compressed/compressed.py
@@ -278,6 +278,29 @@ class GCXS(SparseArray, NDArrayOperatorsMixin):
         return self.data.shape[0]
 
     @property
+    def format(self):
+        """
+        The storage format of this array.
+        Returns
+        -------
+        str
+            The storage format of this array.
+        See Also
+        -------
+        scipy.sparse.dok_matrix.format : The Scipy equivalent property.
+        Examples
+        -------
+        >>> import sparse
+        >>> s = sparse.random((5,5), density=0.2, format='dok')
+        >>> s.format
+        'dok'
+        >>> t = sparse.random((5,5), density=0.2, format='coo')
+        >>> t.format
+        'coo'
+        """
+        return "gcxs"
+
+    @property
     def nbytes(self):
         """
         The number of bytes taken up by this object. Note that for small arrays,

--- a/sparse/_compressed/compressed.py
+++ b/sparse/_compressed/compressed.py
@@ -278,28 +278,6 @@ class GCXS(SparseArray, NDArrayOperatorsMixin):
         return self.data.shape[0]
 
     @property
-    def format(self):
-        """
-        The storage format of this array.
-        Returns
-        -------
-        str
-            The storage format of this array.
-        See Also
-        -------
-        COO.format : Equivalent :obj:`COO` array property.
-        GCXS.format : Equivalent :obj:`GCXS` array property.
-        scipy.sparse.dok_matrix.format : The Scipy equivalent property.
-        Examples
-        -------
-        >>> import sparse
-        >>> s = sparse.random((5,5), density=0.2, format='gcxs')
-        >>> s.format
-        'gcxs'
-        """
-        return "gcxs"
-
-    @property
     def nbytes(self):
         """
         The number of bytes taken up by this object. Note that for small arrays,

--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -624,6 +624,28 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         return self.coords.shape[1]
 
     @property
+    def format(self):
+        """
+        The storage format of this array.
+        Returns
+        -------
+        str
+            The storage format of this array.
+        See Also
+        -------
+        COO.format : Equivalent :obj:`COO` array property.
+        GCXS.format : Equivalent :obj:`GCXS` array property.
+        scipy.sparse.dok_matrix.format : The Scipy equivalent property.
+        Examples
+        -------
+        >>> import sparse
+        >>> s = sparse.random((5,5), density=0.2, format='coo')
+        >>> s.format
+        'coo'
+        """
+        return "coo"
+
+    @property
     def nbytes(self):
         """
         The number of bytes taken up by this object. Note that for small arrays,

--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -624,28 +624,6 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         return self.coords.shape[1]
 
     @property
-    def format(self):
-        """
-        The storage format of this array.
-        Returns
-        -------
-        str
-            The storage format of this array.
-        See Also
-        -------
-        COO.format : Equivalent :obj:`COO` array property.
-        GCXS.format : Equivalent :obj:`GCXS` array property.
-        scipy.sparse.dok_matrix.format : The Scipy equivalent property.
-        Examples
-        -------
-        >>> import sparse
-        >>> s = sparse.random((5,5), density=0.2, format='coo')
-        >>> s.format
-        'coo'
-        """
-        return "coo"
-
-    @property
     def nbytes(self):
         """
         The number of bytes taken up by this object. Note that for small arrays,

--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -624,6 +624,29 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         return self.coords.shape[1]
 
     @property
+    def format(self):
+        """
+        The storage format of this array.
+        Returns
+        -------
+        str
+            The storage format of this array.
+        See Also
+        -------
+        scipy.sparse.dok_matrix.format : The Scipy equivalent property.
+        Examples
+        -------
+        >>> import sparse
+        >>> s = sparse.random((5,5), density=0.2, format='dok')
+        >>> s.format
+        'dok'
+        >>> t = sparse.random((5,5), density=0.2, format='coo')
+        >>> t.format
+        'coo'
+        """
+        return "coo"
+
+    @property
     def nbytes(self):
         """
         The number of bytes taken up by this object. Note that for small arrays,

--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -91,6 +91,7 @@ class DOK(SparseArray, NDArrayOperatorsMixin):
     >>> s6
     <DOK: shape=(5, 5, 5), dtype=int64, nnz=1, fill_value=0.0>
     """
+    format = self.format()
 
     def __init__(self, shape, data=None, dtype=None, fill_value=None):
         from ._coo import COO

--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -91,7 +91,6 @@ class DOK(SparseArray, NDArrayOperatorsMixin):
     >>> s6
     <DOK: shape=(5, 5, 5), dtype=int64, nnz=1, fill_value=0.0>
     """
-    format = self.format()
 
     def __init__(self, shape, data=None, dtype=None, fill_value=None):
         from ._coo import COO

--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -245,29 +245,6 @@ class DOK(SparseArray, NDArrayOperatorsMixin):
         return ar
 
     @property
-    def format(self):
-        """
-        The storage format of this array.
-        Returns
-        -------
-        str
-            The storage format of this array.
-        See Also
-        -------
-        scipy.sparse.dok_matrix.format : The Scipy equivalent property.
-        Examples
-        -------
-        >>> import sparse
-        >>> s = sparse.random((5,5), density=0.2, format='dok')
-        >>> s.format
-        'dok'
-        >>> t = sparse.random((5,5), density=0.2, format='coo')
-        >>> t.format
-        'coo'
-        """
-        return "dok"
-
-    @property
     def nnz(self):
         """
         The number of nonzero elements in this array.
@@ -294,6 +271,29 @@ class DOK(SparseArray, NDArrayOperatorsMixin):
         1
         """
         return len(self.data)
+
+    @property
+    def format(self):
+        """
+        The storage format of this array.
+        Returns
+        -------
+        str
+            The storage format of this array.
+        See Also
+        -------
+        scipy.sparse.dok_matrix.format : The Scipy equivalent property.
+        Examples
+        -------
+        >>> import sparse
+        >>> s = sparse.random((5,5), density=0.2, format='dok')
+        >>> s.format
+        'dok'
+        >>> t = sparse.random((5,5), density=0.2, format='coo')
+        >>> t.format
+        'coo'
+        """
+        return "dok"
 
     @property
     def nbytes(self):

--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -273,29 +273,6 @@ class DOK(SparseArray, NDArrayOperatorsMixin):
         return len(self.data)
 
     @property
-    def format(self):
-        """
-        The storage format of this array.
-
-        Returns
-        -------
-        str
-            The storage format of this array.
-        See Also
-        -------
-        COO.format : Equivalent :obj:`COO` array property.
-        GCXS.format : Equivalent :obj:`GCXS` array property.
-        scipy.sparse.dok_matrix.format : The Scipy equivalent property.
-        Examples
-        -------
-        >>> import sparse
-        >>> s = sparse.random((5,5), density=0.2, format='dok')
-        >>> s.format
-        'dok'
-        """
-        return "dok"
-
-    @property
     def nbytes(self):
         """
         The number of bytes taken up by this object. Note that for small arrays,

--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -245,6 +245,29 @@ class DOK(SparseArray, NDArrayOperatorsMixin):
         return ar
 
     @property
+    def format(self):
+        """
+        The storage format of this array.
+        Returns
+        -------
+        str
+            The storage format of this array.
+        See Also
+        -------
+        scipy.sparse.dok_matrix.format : The Scipy equivalent property.
+        Examples
+        -------
+        >>> import sparse
+        >>> s = sparse.random((5,5), density=0.2, format='dok')
+        >>> s.format
+        'dok'
+        >>> t = sparse.random((5,5), density=0.2, format='coo')
+        >>> t.format
+        'coo'
+        """
+        return "dok"
+
+    @property
     def nnz(self):
         """
         The number of nonzero elements in this array.

--- a/sparse/_sparse_array.py
+++ b/sparse/_sparse_array.py
@@ -192,29 +192,6 @@ class SparseArray:
             If the format isn't supported.
         """
 
-    @classmethod
-    def format(cls):
-        """
-        The storage format of this array.
-        Returns
-        -------
-        str
-            The storage format of this array.
-        See Also
-        -------
-        scipy.sparse.dok_matrix.format : The Scipy equivalent property.
-        Examples
-        -------
-        >>> import sparse
-        >>> s = sparse.random((5,5), density=0.2, format='dok')
-        >>> s.format
-        'dok'
-        >>> t = sparse.random((5,5), density=0.2, format='coo')
-        >>> t.format
-        'coo'
-        """
-        return cls.__name__.lower()
-
     @abstractmethod
     def todense(self):
         """

--- a/sparse/_sparse_array.py
+++ b/sparse/_sparse_array.py
@@ -192,8 +192,8 @@ class SparseArray:
             If the format isn't supported.
         """
 
-    @classmethod
     @property
+    @classmethod
     def format(cls):
         """
         The storage format of this array.

--- a/sparse/_sparse_array.py
+++ b/sparse/_sparse_array.py
@@ -192,8 +192,8 @@ class SparseArray:
             If the format isn't supported.
         """
 
-    @property
     @classmethod
+    @property
     def format(cls):
         """
         The storage format of this array.

--- a/sparse/_sparse_array.py
+++ b/sparse/_sparse_array.py
@@ -203,8 +203,6 @@ class SparseArray:
             The storage format of this array.
         See Also
         -------
-        COO.format : Equivalent :obj:`COO` array property.
-        GCXS.format : Equivalent :obj:`GCXS` array property.
         scipy.sparse.dok_matrix.format : The Scipy equivalent property.
         Examples
         -------

--- a/sparse/_sparse_array.py
+++ b/sparse/_sparse_array.py
@@ -192,6 +192,32 @@ class SparseArray:
             If the format isn't supported.
         """
 
+    @classmethod
+    @property
+    def format(cls):
+        """
+        The storage format of this array.
+        Returns
+        -------
+        str
+            The storage format of this array.
+        See Also
+        -------
+        COO.format : Equivalent :obj:`COO` array property.
+        GCXS.format : Equivalent :obj:`GCXS` array property.
+        scipy.sparse.dok_matrix.format : The Scipy equivalent property.
+        Examples
+        -------
+        >>> import sparse
+        >>> s = sparse.random((5,5), density=0.2, format='dok')
+        >>> s.format
+        'dok'
+        >>> t = sparse.random((5,5), density=0.2, format='coo')
+        >>> t.format
+        'coo'
+        """
+        return cls.__name__.lower()
+
     @abstractmethod
     def todense(self):
         """

--- a/sparse/_sparse_array.py
+++ b/sparse/_sparse_array.py
@@ -193,7 +193,6 @@ class SparseArray:
         """
 
     @classmethod
-    @property
     def format(cls):
         """
         The storage format of this array.

--- a/sparse/tests/test_array_function.py
+++ b/sparse/tests/test_array_function.py
@@ -96,4 +96,4 @@ def test_zeros_like_order():
 @pytest.mark.parametrize("format", ["dok", "gcxs", "coo"])
 def test_format(func):
     s = sparse.random((5, 5), density=0.2, format=format)
-    assert s.format = format
+    assert s.format == format

--- a/sparse/tests/test_array_function.py
+++ b/sparse/tests/test_array_function.py
@@ -93,6 +93,7 @@ def test_zeros_like_order():
     assert isinstance(actual, sparse.COO)
     assert_eq(actual, expected)
 
+
 @pytest.mark.parametrize("format", ["dok", "gcxs", "coo"])
 def test_format(format):
     s = sparse.random((5, 5), density=0.2, format=format)

--- a/sparse/tests/test_array_function.py
+++ b/sparse/tests/test_array_function.py
@@ -92,3 +92,8 @@ def test_zeros_like_order():
 
     assert isinstance(actual, sparse.COO)
     assert_eq(actual, expected)
+
+@pytest.mark.parametrize("format", ["dok", "gcxs", "coo"])
+def test_format(func):
+    s = sparse.random((5, 5), density=0.2, format=format)
+    assert s.format = format

--- a/sparse/tests/test_array_function.py
+++ b/sparse/tests/test_array_function.py
@@ -94,6 +94,6 @@ def test_zeros_like_order():
     assert_eq(actual, expected)
 
 @pytest.mark.parametrize("format", ["dok", "gcxs", "coo"])
-def test_format(func):
+def test_format(format):
     s = sparse.random((5, 5), density=0.2, format=format)
     assert s.format == format


### PR DESCRIPTION
Currently, only 'dok' supports `.format`:

```python
import sparse

for format in ["dok", "gcxs", "coo"]:
    s = sparse.random((5, 5), density=0.2, format=format)
    print(s.format)
# dok
# AttributeError: 'GCXS' object has no attribute 'format'
# AttributeError: 'COO' object has no attribute 'format'
```