### PR TITLE
Ensure correct NNZ when a zero dimensional array contains a value

### DIFF
--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -621,6 +621,8 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         >>> np.count_nonzero(x) == s.nnz
         True
         """
+        if self.shape == ():
+            return len(self.data)
         return self.coords.shape[1]
 
     @property

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1608,16 +1608,18 @@ def test_random_idx_dtype():
     with pytest.raises(ValueError):
         sparse.random((300,), density=0.1, format="coo", idx_dtype=np.int8)
 
+
 def test_nnz_for_zero_dimensional_array():
-    a = np.array(1)
+    a = sparse.COO.from_numpy(np.array(1))
     assert a.shape == ()
     assert a.ndim == 0
     assert a.nnz == 1
 
-    a = sparse.COO.from_numpy(np.array(()))
+    a = sparse.COO.from_numpy(np.array(0))
     assert a.shape == ()
     assert a.ndim == 0
     assert a.nnz == 0
+
 
 def test_html_for_size_zero():
     arr = sparse.COO.from_numpy(np.array(()))

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1608,6 +1608,16 @@ def test_random_idx_dtype():
     with pytest.raises(ValueError):
         sparse.random((300,), density=0.1, format="coo", idx_dtype=np.int8)
 
+def test_nnz_for_zero_dimensional_array():
+    a = np.array(1)
+    assert a.shape == ()
+    assert a.ndim == 0
+    assert a.nnz == 1
+
+    a = sparse.COO.from_numpy(np.array(()))
+    assert a.shape == ()
+    assert a.ndim == 0
+    assert a.nnz == 0
 
 def test_html_for_size_zero():
     arr = sparse.COO.from_numpy(np.array(()))


### PR DESCRIPTION
Currently COO will return NNZ=0 even if there is data in a zero dimensional array, this is a fix for that.