### PR TITLE
Minor bug: import warnings in `_sparse_array.SparseArray`

### DIFF
--- a/sparse/_sparse_array.py
+++ b/sparse/_sparse_array.py
@@ -4,6 +4,7 @@ from numbers import Integral
 from typing import Callable
 import operator
 from functools import reduce
+import warnings
 
 import numpy as np
 import scipy.sparse as ss


### PR DESCRIPTION
I noticed that `SparseArray.var` can potentially try to call `warnings.warn` ([here](https://github.com/pydata/sparse/blob/master/sparse/_sparse_array.py#L767)) but it was never imported.