### PR TITLE
Preserve gcxs compression

### DIFF
--- a/sparse/_umath.py
+++ b/sparse/_umath.py
@@ -412,6 +412,7 @@ class _Elemwise:
 
         processed_args = []
         out_type = GCXS
+        out_kwargs = {}
 
         sparse_args = [arg for arg in args if isinstance(arg, SparseArray)]
 
@@ -421,6 +422,7 @@ class _Elemwise:
             out_type = DOK
         elif all(isinstance(arg, GCXS) for arg in sparse_args):
             out_type = GCXS
+            out_kwargs["compressed_axes"] = sparse_args[0].compressed_axes
         else:
             out_type = COO
 
@@ -441,6 +443,7 @@ class _Elemwise:
                 return
 
         self.out_type = out_type
+        self.out_kwargs = out_kwargs
         self.args = tuple(processed_args)
         self.func = func
         self.dtype = kwargs.pop("dtype", None)
@@ -497,7 +500,7 @@ class _Elemwise:
             shape=self.shape,
             has_duplicates=False,
             fill_value=self.fill_value,
-        ).asformat(self.out_type)
+        ).asformat(self.out_type, **self.out_kwargs)
 
     def _get_fill_value(self):
         """

--- a/sparse/_umath.py
+++ b/sparse/_umath.py
@@ -422,7 +422,8 @@ class _Elemwise:
             out_type = DOK
         elif all(isinstance(arg, GCXS) for arg in sparse_args):
             out_type = GCXS
-            out_kwargs["compressed_axes"] = sparse_args[0].compressed_axes
+            if len({arg.compressed_axes for arg in sparse_args}) == 1:
+                out_kwargs["compressed_axes"] = sparse_args[0].compressed_axes
         else:
             out_type = COO
 


### PR DESCRIPTION
This PR closes #596 in a fairly simple way: if all of the inputs are GCXS arrays and they have the same compression, it will return the output with the same compression. I just do this by storing a `kwargs` dictionary during the `_Elemwise` initialization.

A further enhancement that I'm exploring: if the `ufunc` has a single input, we could avoid the conversion to `COO` entirely, as well as skip some other checks. In this case we know that our argument is sparse (or we wouldn't be creating this class) and we know that it "broadcasts" to the same shape. The things to consider are the potential keywords for the ufunc: `where`, `out`, etc.