### PR TITLE
Use matrepr for rich `__str__` and `_repr_html_`

### DIFF
--- a/sparse/_compressed/compressed.py
+++ b/sparse/_compressed/compressed.py
@@ -344,9 +344,10 @@ class GCXS(SparseArray, NDArrayOperatorsMixin):
         return self.transpose()
 
     def __str__(self):
-        return "<GCXS: shape={}, dtype={}, nnz={}, fill_value={}, compressed_axes={}>".format(
+        summary = "<GCXS: shape={}, dtype={}, nnz={}, fill_value={}, compressed_axes={}>".format(
             self.shape, self.dtype, self.nnz, self.fill_value, self.compressed_axes
         )
+        return self._str_impl(summary)
 
     __repr__ = __str__
 
@@ -864,13 +865,14 @@ class _Compressed2d(GCXS):
         )
 
     def __str__(self):
-        return "<{}: shape={}, dtype={}, nnz={}, fill_value={}>".format(
+        summary = "<{}: shape={}, dtype={}, nnz={}, fill_value={}>".format(
             type(self).__name__,
             self.shape,
             self.dtype,
             self.nnz,
             self.fill_value,
         )
+        return self._str_impl(summary)
 
     __repr__ = __str__
 

--- a/sparse/_coo/core.py
+++ b/sparse/_coo/core.py
@@ -702,9 +702,10 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
     __getitem__ = getitem
 
     def __str__(self):
-        return "<COO: shape={!s}, dtype={!s}, nnz={:d}, fill_value={!s}>".format(
+        summary = "<COO: shape={!s}, dtype={!s}, nnz={:d}, fill_value={!s}>".format(
             self.shape, self.dtype, self.nnz, self.fill_value
         )
+        return self._str_impl(summary)
 
     __repr__ = __str__
 

--- a/sparse/_dok.py
+++ b/sparse/_dok.py
@@ -451,9 +451,10 @@ class DOK(SparseArray, NDArrayOperatorsMixin):
             del self.data[key]
 
     def __str__(self):
-        return "<DOK: shape={!s}, dtype={!s}, nnz={:d}, fill_value={!s}>".format(
+        summary = "<DOK: shape={!s}, dtype={!s}, nnz={:d}, fill_value={!s}>".format(
             self.shape, self.dtype, self.nnz, self.fill_value
         )
+        return self._str_impl(summary)
 
     __repr__ = __str__
 

--- a/sparse/_sparse_array.py
+++ b/sparse/_sparse_array.py
@@ -170,7 +170,40 @@ class SparseArray:
         Diagnostic report about this array.
         Renders in Jupyter.
         """
-        return html_table(self)
+        try:
+            from matrepr import to_html
+            from matrepr.adapters.sparse_driver import PyDataSparseDriver
+            return to_html(PyDataSparseDriver.adapt(self), notebook=True)
+        except ImportError:
+            return html_table(self)
+
+    def _str_impl(self, summary):
+        """
+        A human-readable representation of this array, including a metadata summary
+        and a tabular view of the array values.
+
+        Values view only included if `matrepr` is available.
+
+        Parameters
+        ----------
+        summary
+            A type-specific summary of this array, used as the first line of return value.
+
+        Returns
+        -------
+        str
+            A human-readable representation of this array.
+        """
+        try:
+            from matrepr import to_str
+            from matrepr.adapters.sparse_driver import PyDataSparseDriver
+            values =  to_str(PyDataSparseDriver.adapt(self),
+                             title=False,  # disable matrepr description
+                             width_str=0,  # autodetect terminal width
+                             max_cols=9999)
+            return "\n".join([summary, values])
+        except ImportError:
+            return summary
 
     @abstractmethod
     def asformat(self, format):

--- a/sparse/_sparse_array.py
+++ b/sparse/_sparse_array.py
@@ -173,6 +173,7 @@ class SparseArray:
         try:
             from matrepr import to_html
             from matrepr.adapters.sparse_driver import PyDataSparseDriver
+
             return to_html(PyDataSparseDriver.adapt(self), notebook=True)
         except ImportError:
             return html_table(self)
@@ -197,10 +198,13 @@ class SparseArray:
         try:
             from matrepr import to_str
             from matrepr.adapters.sparse_driver import PyDataSparseDriver
-            values =  to_str(PyDataSparseDriver.adapt(self),
-                             title=False,  # disable matrepr description
-                             width_str=0,  # autodetect terminal width
-                             max_cols=9999)
+
+            values = to_str(
+                PyDataSparseDriver.adapt(self),
+                title=False,  # disable matrepr description
+                width_str=0,  # autodetect terminal width
+                max_cols=9999,
+            )
             return "\n".join([summary, values])
         except ImportError:
             return summary


### PR DESCRIPTION
If available, use the [matrepr](https://github.com/alugowski/matrepr) package to render array values in string and HTML output.

Reverts to current behavior if matrepr is not installed.

See this [Jupyter notebook](https://nbviewer.org/github/alugowski/matrepr/blob/main/doc/demo-pydata-sparse.ipynb) for a demo of what 1D, 2D, and 3D sparse arrays look like when rendered by matrepr.

Closes #604