### PR TITLE
DOC: Add array representations to sparse array construction examples

### DIFF
--- a/docs/construct.rst
+++ b/docs/construct.rst
@@ -20,13 +20,16 @@ matrix:
    ...           [0, 1, 2, 3, 4]]
    >>> data = [10, 20, 30, 40, 50]
    >>> s = sparse.COO(coords, data, shape=(5, 5))
-
-   >>> s.todense()
-   array([[10,  0,  0,  0,  0],
-          [ 0, 20,  0,  0,  0],
-          [ 0,  0, 30,  0,  0],
-          [ 0,  0,  0, 40,  0],
-          [ 0,  0,  0,  0, 50]])
+   >>> s
+   <COO: shape=(5, 5), dtype=int64, nnz=5, fill_value=0>
+        0    1    2    3    4
+     ┌                         ┐
+   0 │ 10                      │
+   1 │      20                 │
+   2 │           30            │
+   3 │                40       │
+   4 │                     50  │
+     └                         ┘
 
 In general :code:`coords` should be a :code:`(ndim, nnz)` shaped
 array. Each row of :code:`coords` contains one dimension of the
@@ -47,6 +50,15 @@ identity matrix:
    ...           [0, 1, 2, 3]]
    >>> data = 1
    >>> s = sparse.COO(coords, data, shape=(4, 4))
+   >>> s
+   <COO: shape=(4, 4), dtype=int64, nnz=4, fill_value=0>
+        0    1    2    3
+     ┌                    ┐
+   0 │  1                 │
+   1 │       1            │
+   2 │            1       │
+   3 │                 1  │
+     └                    ┘
 
 You can, and should, pass in :obj:`numpy.ndarray` objects for
 :code:`coords` and :code:`data`.
@@ -61,9 +73,19 @@ explicitly. For example, if we did the following without the
 
 .. code-block:: python
 
-   coords = [[0, 3, 2, 1], [4, 1, 2, 0]]
-   data = [1, 4, 2, 1]
-   s = COO(coords, data, shape=(5, 5))
+   >>> coords = [[0, 3, 2, 1], [4, 1, 2, 0]]
+   >>> data = [1, 4, 2, 1]
+   >>> s = COO(coords, data, shape=(5, 5))
+   >>> s
+   <COO: shape=(5, 5), dtype=int64, nnz=4, fill_value=0>
+        0    1    2    3    4
+     ┌                         ┐
+   0 │                      1  │
+   1 │  1                      │
+   2 │            2            │
+   3 │       4                 │
+   4 │                         │
+     └                         ┘
 
 :obj:`COO` arrays support arbitrary fill values. Fill values are the "default"
 value, or value to not store. This can be given a value other than zero. For
@@ -73,9 +95,16 @@ with nonzero fill values.
 
 .. code-block:: python
 
-   coords = [[0, 1], [1, 0]]
-   data = [0, 0]
-   s = COO(coords, data, fill_value=1)
+   >>> coords = [[0, 1], [1, 0]]
+   >>> data = [0, 0]
+   >>> s = COO(coords, data, fill_value=1)
+   >>> s
+   <COO: shape=(2, 2), dtype=int64, nnz=2, fill_value=1>
+        0    1
+     ┌          ┐
+   0 │       0  │
+   1 │  0       │
+     └          ┘
 
 From :std:doc:`Scipy sparse matrices <scipy:reference/generated/scipy.sparse.spmatrix>`
 ---------------------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ tests = [
     "pre-commit",
 ]
 tox = ["sparse[tests]", "tox"]
-all = ["sparse[docs,tox]"]
+all = ["sparse[docs,tox]", "matrepr"]
 
 [project.urls]
 Documentation = "https://sparse.pydata.org/"


### PR DESCRIPTION
Reran the examples in [Construct Sparse Arrays](https://sparse.pydata.org/en/stable/construct.html) with `matrepr` installed to show the result of each snippet.

Previously only the first example showed the result, but only as a dense array. This change illustrates the sparsity of the sparse arrays. Some examples become easier to follow, such as the last example showing a "bad" identity matrix with explicit zeros and a fill value of 1. A visualization of the array reinforces the written description.