### PR TITLE
Fix issue with .real/.imag with string dtypes

### DIFF
--- a/sparse/_umath.py
+++ b/sparse/_umath.py
@@ -533,7 +533,8 @@ class _Elemwise:
         from ._coo import COO
 
         zero_args = tuple(
-            arg.fill_value[...] if isinstance(arg, COO) else arg for arg in self.args
+            np.asarray(arg.fill_value, like=arg.data) if isinstance(arg, COO) else arg
+            for arg in self.args
         )
 
         # Some elemwise functions require a dtype argument, some abhorr it.

--- a/sparse/_utils.py
+++ b/sparse/_utils.py
@@ -18,7 +18,8 @@ def assert_eq(x, y, check_nnz=True, compare_dtype=True, **kwargs):
 
     check_equal = (
         np.array_equal
-        if np.issubdtype(x.dtype, np.integer) and np.issubdtype(y.dtype, np.integer)
+        if (np.issubdtype(x.dtype, np.integer) and np.issubdtype(y.dtype, np.integer))
+        or (np.issubdtype(x.dtype, np.flexible) and np.issubdtype(y.dtype, np.flexible))
         else functools.partial(np.allclose, equal_nan=True)
     )
 

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1370,7 +1370,9 @@ def test_complex_methods(x):
     s = sparse.COO.from_numpy(x)
     assert_eq(s.imag, x.imag)
     assert_eq(s.real, x.real)
-    assert_eq(s.conj(), x.conj())
+
+    if np.issubdtype(s.dtype, np.number):
+        assert_eq(s.conj(), x.conj())
 
 
 def test_np_matrix():

--- a/sparse/tests/test_coo.py
+++ b/sparse/tests/test_coo.py
@@ -1358,12 +1358,15 @@ def test_full_like():
     )
 
 
-@pytest.mark.parametrize("complex", [True, False])
-def test_complex_methods(complex):
-    if complex:
-        x = np.array([1 + 2j, 2 - 1j, 0, 1, 0])
-    else:
-        x = np.array([1, 2, 0, 0, 0])
+@pytest.mark.parametrize(
+    "x",
+    [
+        np.array([1, 2, 0, 0, 0]),
+        np.array([1 + 2j, 2 - 1j, 0, 1, 0]),
+        np.array(["a", "b", "c"]),
+    ],
+)
+def test_complex_methods(x):
     s = sparse.COO.from_numpy(x)
     assert_eq(s.imag, x.imag)
     assert_eq(s.real, x.real)


### PR DESCRIPTION
`np.array("").dtype.type[...]` doesn't work to create an array. 
* Use np.asarray to create the fill value array instead.
* Fix assert_eq so it uses np.array_equal for strings.

Closes #608

References
https://numpy.org/doc/stable/reference/arrays.scalars.html#indexing