### PR TITLE
CI: Remove Python 3.8 and update miniconda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11']
         numba_boundscheck: [0]
         include:
           - os: macos-latest
-            python: '3.10'
+            python: '3.9'
           - os: windows-latest
-            python: '3.10'
+            python: '3.9'
           - os: ubuntu-latest
-            python: '3.10'
+            python: '3.9'
             numba_boundscheck: 1
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -73,13 +73,13 @@ jobs:
           path: ~/conda_pkgs_dir
           key:
             docs-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/environment.yml') }}
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: sparse-dev
           allow-softlinks: true
           environment-file: ci/environment.yml
           python-version: '3.10'
-          miniforge-variant: Mambaforge
+          miniforge-version: latest
           use-only-tar-bz2: true
           use-mamba: true
       - name: Install package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Sparse n-dimensional arrays for the PyData ecosystem"
 readme = "README.rst"
 dependencies = ["numpy>=1.17", "numba>=0.49"]
 maintainers = [{ name = "Hameer Abbasi", email = "hameerabbasi@yahoo.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { file = "LICENSE" }
 keywords = ["sparse", "numpy", "scipy", "dask"]
 classifiers = [
@@ -18,7 +18,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/sparse/_coo/common.py
+++ b/sparse/_coo/common.py
@@ -2,7 +2,7 @@ import operator
 import warnings
 from collections.abc import Iterable
 from functools import reduce
-from typing import Any, NamedTuple, Optional, Tuple
+from typing import Any, NamedTuple, Optional
 
 import numba
 
@@ -1366,7 +1366,7 @@ def _sort_coo(
     fill_value: float,
     sort_axis_len: int,
     descending: bool,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     assert coords.shape[0] == 2
     group_coords = coords[0, :]
     sort_coords = coords[1, :]
@@ -1424,7 +1424,7 @@ def _compute_minmax_args(
     reduce_size: int,
     fill_value: float,
     max_mode_flag: bool,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     assert coords.shape[0] == 2
     reduce_coords = coords[0, :]
     index_coords = coords[1, :]


### PR DESCRIPTION
Hi @hameerabbasi,

This PR introduces CI changes that we did in `finch-tensor`. 