### PR TITLE
Improve performance of GCXS dot ndarray

### DIFF
--- a/benchmarks/benchmark_gcxs.py
+++ b/benchmarks/benchmark_gcxs.py
@@ -67,3 +67,28 @@ class IndexingSuite:
 
     def time_index_fancy(self):
         self.x[self.index]
+
+
+class DenseMultiplySuite:
+    params = ([0, 1], [1, 20, 100])
+    param_names = ["compressed axis", "n_vectors"]
+
+    def setup(self, compressed_axis, n_vecs):
+        rng = np.random.default_rng(1337)
+        n = 10000
+        x = sparse.random((n, n), density=0.001, format="gcxs", random_state=rng).change_compressed_axes(
+            (compressed_axis,)
+        )
+        self.x = x
+        self.t = rng.random((n, n_vecs))
+        self.u = rng.random((n_vecs, n))
+
+        # Numba compilation
+        self.x @ self.t
+        self.u @ self.x
+
+    def time_gcxs_dot_ndarray(self, *args):
+        self.x @ self.t
+
+    def time_ndarray_dot_gcxs(self, *args):
+        self.u @ self.x

--- a/sparse/_common.py
+++ b/sparse/_common.py
@@ -717,15 +717,14 @@ def _dot_csr_ndarray_type(dt1, dt2):
         out_shape : Tuple[int]
             The shape of the output array.
         """
-        out = np.empty(out_shape, dtype=dtr)
+        out = np.zeros(out_shape, dtype=dtr)
         for i in range(out_shape[0]):
-            for j in range(out_shape[1]):
-                val = 0
-                for k in range(a_indptr[i], a_indptr[i + 1]):
-                    ind = a_indices[k]
-                    v = a_data[k]
-                    val += v * b[ind, j]
-                out[i, j] = val
+            val = out[i]
+            for k in range(a_indptr[i], a_indptr[i + 1]):
+                ind = a_indices[k]
+                v = a_data[k]
+                for j in range(out_shape[1]):
+                    val[j] += v * b[ind, j]
         return out
 
     return _dot_csr_ndarray

--- a/sparse/_common.py
+++ b/sparse/_common.py
@@ -869,8 +869,11 @@ def _dot_csc_ndarray_type(dt1, dt2):
         out = np.zeros((a_shape[0], b_shape[1]), dtype=dtr)
         for i in range(b_shape[0]):
             for k in range(a_indptr[i], a_indptr[i + 1]):
+                ind = a_indices[k]
+                v = a_data[k]
+                val = out[ind]
                 for j in range(b_shape[1]):
-                    out[a_indices[k], j] += a_data[k] * b[i, j]
+                    val[j] += v * b[i, j]
         return out
 
     return _dot_csc_ndarray

--- a/sparse/_common.py
+++ b/sparse/_common.py
@@ -866,9 +866,9 @@ def _dot_csc_ndarray_type(dt1, dt2):
             The shapes of the input arrays.
         """
         out = np.zeros((a_shape[0], b_shape[1]), dtype=dtr)
-        for j in range(b_shape[1]):
-            for i in range(b_shape[0]):
-                for k in range(a_indptr[i], a_indptr[i + 1]):
+        for i in range(b_shape[0]):
+            for k in range(a_indptr[i], a_indptr[i + 1]):
+                for j in range(b_shape[1]):
                     out[a_indices[k], j] += a_data[k] * b[i, j]
         return out
 

--- a/sparse/_common.py
+++ b/sparse/_common.py
@@ -718,6 +718,7 @@ def _dot_csr_ndarray_type(dt1, dt2):
         out_shape : Tuple[int]
             The shape of the output array.
         """
+        b = np.ascontiguousarray(b)  # ensure memory aligned
         out = np.zeros(out_shape, dtype=dtr)
         for i in range(out_shape[0]):
             val = out[i]
@@ -866,6 +867,7 @@ def _dot_csc_ndarray_type(dt1, dt2):
         a_shape, b_shape : Tuple[int]
             The shapes of the input arrays.
         """
+        b = np.ascontiguousarray(b)  # ensure memory aligned
         out = np.zeros((a_shape[0], b_shape[1]), dtype=dtr)
         for i in range(b_shape[0]):
             for k in range(a_indptr[i], a_indptr[i + 1]):


### PR DESCRIPTION
Improves the memory access pattern for `GCXS` arrays dot `ndarray`s.

Was running a few benchmarks of the GCXS class against scipy's csr/csc arrays and noticed that they were significantly slower. So was curious what the biggest difference was as their structures shouldn't be too fundamentally different. When looking at the csr_dot_ndarray code and the csc_dot_ndarray code I realized that the access pattern of the arrays was inefficient.

Here are some of the relevant timings of things:
```python
import scipy.sparse as sp
import sparse
import numpy as np
```


```python
state = np.random.default_rng(seed=1337)
A_gc0s = sparse.random((9000, 10000), format='gcxs', random_state=state).change_compressed_axes((0,))
A_gc1s = A_gc0s.change_compressed_axes((1,))
A_csr = A_gc0s.to_scipy_sparse()
A_csc = A_gc1s.to_scipy_sparse()

n_vecs = 20
n_broadcasted = 5

v = state.random((A_gc0s.shape[1], n_vecs))
u = state.random((n_broadcasted, A_gc0s.shape[1], n_vecs))
x = state.random((n_vecs, A_gc0s.shape[0]))
```

### Scipy Timing:


```python
%timeit A_csr @ v
```

    18.1 ms ± 1.32 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)
    


```python
%timeit A_csc @ v
```

    19 ms ± 1.03 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)
    


```python
%timeit x @ A_csr
```

    21.9 ms ± 3.39 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
    


```python
%timeit x @ A_csc
```

    21 ms ± 1.66 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)
    

### Sparse timing:


```python
# trigger compilers
A_gc0s @ v
A_gc1s @ v
x @ A_gc0s
x @ A_gc1s
A_gc0s @ u
A_gc1s @ u;
```

Timing on main:


```python
%timeit A_gc0s @ v
```

    58.4 ms ± 4.67 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
    


```python
%timeit A_gc1s @ v
```

    179 ms ± 7.31 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
    


```python
%timeit A_gc0s @ u
```

    336 ms ± 44.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
    


```python
%timeit A_gc1s @ u
```

    1.06 s ± 80 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
    


```python
%timeit x @ A_gc0s
```

    126 ms ± 7.89 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
    


```python
%timeit x @ A_gc1s
```

    55.7 ms ± 2.14 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
    

Timing on PR:


```python
%timeit A_gc0s @ v
```

    19.8 ms ± 2.48 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
    


```python
%timeit A_gc1s @ v
```

    23.4 ms ± 2.87 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
    


```python
%timeit A_gc0s @ u
```

    65 ms ± 5.07 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
    


```python
%timeit A_gc1s @ u
```

    77 ms ± 5.94 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
    


```python
%timeit x @ A_gc0s
```

    32.8 ms ± 3.43 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
    


```python
%timeit x @ A_gc1s
```

    57.6 ms ± 3.7 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)


The left ndarray dot GCXS arrays are still a little slower than I'd like, but couldn't quite see where to dive into that at, as it looks like it's doing what it should be for the matvec operation (basically just doing `(GCXS.T @ x.T).T`)


One other thing, for 1D ndarrays numba doesn't seem to be able to optimize these as well as it could (considering benchmarks with scipy csr/csc times a 1D array). There should likely be a branching for 1D ndarrays to use a version that doesn't include the loop over the second dimension.