### PR TITLE
API: Enable finch backend for `scipy.sparse`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ tests = [
 ]
 tox = ["sparse[tests]", "tox"]
 all = ["sparse[docs,tox]", "matrepr"]
-finch = ["finch-tensor>=0.1.9"]
+finch = ["finch-tensor>=0.1.10"]
 
 [project.urls]
 Documentation = "https://sparse.pydata.org/"

--- a/sparse/finch_backend/__init__.py
+++ b/sparse/finch_backend/__init__.py
@@ -4,6 +4,7 @@ except ModuleNotFoundError as e:
     raise ImportError("Finch not installed. Run `pip install sparse[finch]` to enable Finch backend") from e
 
 from finch import (
+    SparseArray,
     abs,
     acos,
     acosh,
@@ -56,6 +57,7 @@ from finch import (
 )
 
 __all__ = [
+    "SparseArray",
     "abs",
     "acos",
     "acosh",

--- a/sparse/tests/test_backends.py
+++ b/sparse/tests/test_backends.py
@@ -59,18 +59,17 @@ def test_finch_backend():
         assert_equal(result.todense(), np.sum(2 * np_eye, axis=0))
 
 
-@pytest.mark.parametrize("format", ["csc", "csr", "coo"])
-def test_asarray(backend, format):
-    arr = np.eye(5)
+@pytest.mark.parametrize("format, order", [("csc", "F"), ("csr", "C"), ("coo", "F"), ("coo", "C")])
+def test_asarray(backend, format, order):
+    arr = np.eye(5, order=order)
 
     result = sparse.asarray(arr, format=format)
 
     assert_equal(result.todense(), arr)
 
 
-@pytest.mark.parametrize("format_with_order", [("csc", "F"), ("csr", "C"), ("coo", "F"), ("coo", "C")])
-def test_scipy_sparse_dispatch(backend, format_with_order):
-    format, order = format_with_order
+@pytest.mark.parametrize("format, order", [("csc", "F"), ("csr", "C"), ("coo", "F"), ("coo", "C")])
+def test_scipy_sparse_dispatch(backend, format, order):
     x = np.eye(10, order=order) * 2
     y = np.ones((10, 1), order=order)
 

--- a/sparse/tests/test_backends.py
+++ b/sparse/tests/test_backends.py
@@ -4,7 +4,8 @@ import pytest
 
 import numpy as np
 import scipy.sparse as sp
-from numpy.testing import assert_equal
+import scipy.sparse.linalg as splin
+from numpy.testing import assert_almost_equal, assert_equal
 
 
 def test_backend_contex_manager(backend):
@@ -65,3 +66,18 @@ def test_asarray(backend, format):
     result = sparse.asarray(arr, format=format)
 
     assert_equal(result.todense(), arr)
+
+
+@pytest.mark.parametrize("format_with_order", [("csc", "F"), ("csr", "C"), ("coo", "F"), ("coo", "C")])
+def test_scipy_sparse_dispatch(backend, format_with_order):
+    format, order = format_with_order
+    x = np.eye(10, order=order) * 2
+    y = np.ones((10, 1), order=order)
+
+    x_sp = sparse.asarray(x, format=format)
+    y_sp = sparse.asarray(y, format="coo")
+
+    actual = splin.spsolve(x_sp, y_sp)
+    expected = np.linalg.solve(x, y.ravel())
+
+    assert_almost_equal(actual, expected)


### PR DESCRIPTION
Hi @hameerabbasi,

Once https://github.com/willow-ahrens/finch-tensor/pull/31 is merged this PR will make sure that `scipy.sparse` also accepts finch-backend tensors! 