### PR TITLE
Do strict checking of Array API in CI job.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ source=
 omit=
     sparse/_version.py
     sparse/tests/*
+    sparse/numba_backend/tests/*
 
 [report]
 exclude_lines =

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
         SPARSE_BACKEND: Finch
       run: |
         cd ${GITHUB_WORKSPACE}/array-api-tests
-        pytest array_api_tests/test_signatures.py -v -c pytest.ini --ci --max-examples=2 --derandomize --disable-deadline --skips-file ${GITHUB_WORKSPACE}/ci/array-api-skips.txt
+        pytest array_api_tests/test_signatures.py -v -c pytest.ini --ci --max-examples=2 --derandomize --disable-deadline -o xfail_strict=True --xfails-file ${GITHUB_WORKSPACE}/ci/array-api-skips.txt
 on:
   # Trigger the workflow on push or pull request,
   # but only for the main branch

--- a/ci/array-api-skips.txt
+++ b/ci/array-api-skips.txt
@@ -36,12 +36,6 @@ array_api_tests/test_signatures.py::test_func_signature[iinfo]
 array_api_tests/test_signatures.py::test_func_signature[result_type]
 
 # bitwise functions
-array_api_tests/test_signatures.py::test_func_signature[bitwise_left_shift]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_invert]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_right_shift]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_and]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_or]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_xor]
 array_api_tests/test_signatures.py::test_func_signature[logical_and]
 array_api_tests/test_signatures.py::test_func_signature[logical_not]
 array_api_tests/test_signatures.py::test_func_signature[logical_or]
@@ -49,7 +43,6 @@ array_api_tests/test_signatures.py::test_func_signature[logical_xor]
 
 # other functions
 array_api_tests/test_signatures.py::test_func_signature[concat]
-array_api_tests/test_signatures.py::test_func_signature[permute_dims]
 array_api_tests/test_signatures.py::test_func_signature[reshape]
 array_api_tests/test_signatures.py::test_func_signature[argsort]
 array_api_tests/test_signatures.py::test_func_signature[sort]


### PR DESCRIPTION
@mtsokol This will do what I suggested in https://github.com/pydata/sparse/pull/668#issuecomment-2079356755, in that we're required to remove tests that pass from the skips file. This will ensure that we don't regress and remember to update the file as well.