### PR TITLE
Add `SDDMM` example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,21 @@ jobs:
       - name: Run benchmarks
         run: |
           asv run --quick
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5.1.0
+      with:
+        python-version: '3.11'
+    - name: Build and install Sparse
+      run: |
+        python -m pip install '.[finch]' scipy
+    - name: Run examples
+      run: |
+        source ci/test_examples.sh
   array_api_tests:
     runs-on: ubuntu-latest
     steps:

--- a/benchmarks/benchmark_backends.py
+++ b/benchmarks/benchmark_backends.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from .utils import SkipNotImplemented
 
-TIMEOUT: float = 200.0
+TIMEOUT: float = 300.0
 BACKEND: sparse.BackendType = sparse.backend_var.get()
 
 

--- a/benchmarks/benchmark_backends.py
+++ b/benchmarks/benchmark_backends.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from .utils import SkipNotImplemented
 
-TIMEOUT: float = 300.0
+TIMEOUT: float = 500.0
 BACKEND: sparse.BackendType = sparse.backend_var.get()
 
 
@@ -42,8 +42,7 @@ class Tensordot:
 
 class SpMv:
     timeout = TIMEOUT
-    # NOTE: https://github.com/willow-ahrens/Finch.jl/issues/488
-    params = [[True, False], [(10, 0.01)]]  # (1000, 0.01), (1_000_000, 1e-05)
+    params = [[True, False], [(50, 0.1)]]  # (1000, 0.01), (1_000_000, 1e-05)
     param_names = ["lazy_mode", "size_and_density"]
 
     def setup(self, lazy_mode, size_and_density):
@@ -55,9 +54,8 @@ class SpMv:
             random_kwargs["format"] = "gcxs"
 
         self.M = sparse.random((size, size), **random_kwargs)
-        # NOTE: Once https://github.com/willow-ahrens/Finch.jl/issues/487 is fixed change to (size, 1).
-        self.v1 = rng.normal(size=(size, 2))
-        self.v2 = rng.normal(size=(size, 2))
+        self.v1 = rng.normal(size=(size, 1))
+        self.v2 = rng.normal(size=(size, 1))
 
         if sparse.BackendType.Finch == BACKEND:
             import finch

--- a/ci/test_examples.sh
+++ b/ci/test_examples.sh
@@ -1,0 +1,3 @@
+for example in $(find ./examples/ -iname *.py); do
+  python $example
+done

--- a/examples/sddmm_example.py
+++ b/examples/sddmm_example.py
@@ -1,0 +1,65 @@
+import time
+
+import sparse
+
+import numpy as np
+import scipy.sparse as sps
+
+LEN = 1000
+DENSITY = 0.0001
+ITERS = 3
+rng = np.random.default_rng()
+
+
+def benchmark(func, info, args):
+    print(info)
+    start = time.time()
+    for i in range(ITERS):
+        print(f"iter: {i}")
+        func(*args)
+    elapsed = time.time() - start
+    print(f"Took {elapsed / ITERS} s.\n")
+
+
+if __name__ == "__main__":
+    # Finch
+    with sparse.Backend(backend=sparse.BackendType.Finch):
+        s = sparse.random((LEN, LEN), density=DENSITY, random_state=rng)
+        a = sparse.asarray(np.array(rng.random((LEN, LEN)), order="F"))
+        b = sparse.asarray(np.array(rng.random((LEN, LEN)), order="F"))
+
+        @sparse.compiled
+        def sddmm_finch(s, a, b):
+            return sparse.sum(s[:, :, None] * (a[:, None, :] * b[None, :, :]), axis=-1)
+
+        # Compile
+        result_finch = sddmm_finch(s, a, b)
+        assert sparse.nonzero(result_finch)[0].size > 5
+        # Benchmark
+        benchmark(sddmm_finch, info="Finch", args=[s, a, b])
+
+    # Numba
+    with sparse.Backend(backend=sparse.BackendType.Numba):
+        s = sparse.random((LEN, LEN), density=DENSITY, random_state=rng)
+        a = rng.random((LEN, LEN))
+        b = rng.random((LEN, LEN))
+
+        def sddmm_numba(s, a, b):
+            return sparse.sum(s[:, :, None] * (a[:, None, :] * b[None, :, :]), axis=-1)
+
+        # Compile
+        result_numba = sddmm_numba(s, a, b)
+        assert sparse.nonzero(result_numba)[0].size > 5
+        # Benchmark
+        benchmark(sddmm_numba, info="Numba", args=[s, a, b])
+
+    # SciPy
+    def sddmm_scipy(s, a, b):
+        return s * (a @ b)
+
+    s = sps.random_array((LEN, LEN), format="coo", density=DENSITY, random_state=rng)
+    a = rng.random((LEN, LEN))
+    b = rng.random((LEN, LEN))
+
+    # Benchmark
+    benchmark(sddmm_scipy, info="SciPy", args=[s, a, b])

--- a/examples/sddmm_example.py
+++ b/examples/sddmm_example.py
@@ -5,28 +5,32 @@ import sparse
 import numpy as np
 import scipy.sparse as sps
 
-LEN = 1000
+LEN = 10000
 DENSITY = 0.0001
-ITERS = 3
-rng = np.random.default_rng()
+ITERS = 5
+rng = np.random.default_rng(0)
 
 
 def benchmark(func, info, args):
     print(info)
     start = time.time()
-    for i in range(ITERS):
-        print(f"iter: {i}")
+    for _ in range(ITERS):
         func(*args)
     elapsed = time.time() - start
     print(f"Took {elapsed / ITERS} s.\n")
 
 
 if __name__ == "__main__":
+    a_sps = rng.random((LEN, LEN - 10)) * 10
+    b_sps = rng.random((LEN, LEN - 10)) * 10
+    s_sps = sps.random(LEN, LEN, format="coo", density=DENSITY, random_state=rng) * 10
+    s_sps.sum_duplicates()
+
     # Finch
     with sparse.Backend(backend=sparse.BackendType.Finch):
-        s = sparse.random((LEN, LEN), density=DENSITY, random_state=rng)
-        a = sparse.asarray(np.array(rng.random((LEN, LEN)), order="F"))
-        b = sparse.asarray(np.array(rng.random((LEN, LEN)), order="F"))
+        s = sparse.asarray(s_sps)
+        a = sparse.asarray(np.array(a_sps, order="F"))
+        b = sparse.asarray(np.array(b_sps, order="F"))
 
         @sparse.compiled
         def sddmm_finch(s, a, b):
@@ -40,12 +44,12 @@ if __name__ == "__main__":
 
     # Numba
     with sparse.Backend(backend=sparse.BackendType.Numba):
-        s = sparse.random((LEN, LEN), density=DENSITY, random_state=rng)
-        a = rng.random((LEN, LEN))
-        b = rng.random((LEN, LEN))
+        s = sparse.asarray(s_sps)
+        a = a_sps
+        b = b_sps
 
         def sddmm_numba(s, a, b):
-            return sparse.sum(s[:, :, None] * (a[:, None, :] * b[None, :, :]), axis=-1)
+            return s * (a @ b.T)
 
         # Compile
         result_numba = sddmm_numba(s, a, b)
@@ -55,11 +59,16 @@ if __name__ == "__main__":
 
     # SciPy
     def sddmm_scipy(s, a, b):
-        return s * (a @ b)
+        return s.multiply(a @ b.T)
 
-    s = sps.random_array((LEN, LEN), format="coo", density=DENSITY, random_state=rng)
-    a = rng.random((LEN, LEN))
-    b = rng.random((LEN, LEN))
+    s = s_sps.asformat("csr")
+    a = a_sps
+    b = b_sps
 
+    result_scipy = sddmm_scipy(s, a, b)
     # Benchmark
     benchmark(sddmm_scipy, info="SciPy", args=[s, a, b])
+
+    np.testing.assert_allclose(result_numba.todense(), result_scipy.toarray())
+    np.testing.assert_allclose(result_finch.todense(), result_numba.todense())
+    np.testing.assert_allclose(result_finch.todense(), result_scipy.toarray())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ tests = [
 ]
 tox = ["sparse[tests]", "tox"]
 all = ["sparse[docs,tox]", "matrepr"]
-finch = ["finch-tensor>=0.1.14"]
+finch = ["finch-tensor>=0.1.17"]
 
 [project.urls]
 Documentation = "https://sparse.pydata.org/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ tests = [
 ]
 tox = ["sparse[tests]", "tox"]
 all = ["sparse[docs,tox]", "matrepr"]
-finch = ["finch-tensor>=0.1.17"]
+finch = ["finch-tensor>=0.1.19"]
 
 [project.urls]
 Documentation = "https://sparse.pydata.org/"


### PR DESCRIPTION
Hi @hameerabbasi,

This PR adds `SDDMM` example and upgrades Finch to the latest version.

**[UPDATED 14.05.2024]**
For my machine, running:
```bash
python examples/sddmm_example.py
```
gives:
```
Finch
Took 8.787564675013224 s.

Numba
Took 22.904020706812542 s.

SciPy
Took 22.59452811876933 s.
```
