### PR TITLE
Add tests for `scipy.sparse.csgraph` and `scipy.sparse.linalg`

### DIFF
--- a/ci/array-api-skips.txt
+++ b/ci/array-api-skips.txt
@@ -1,1 +1,2 @@
 array_api_tests/test_searching_functions.py::test_nonzero_zerodim_error
+array_api_tests/test_special_cases.py::test_unary[sign((x_i is -0 or x_i == +0)) -> 0]

--- a/ci/array-api-xfails.txt
+++ b/ci/array-api-xfails.txt
@@ -303,7 +303,6 @@ array_api_tests/test_special_cases.py::test_unary[signbit(isfinite(x_i) and x_i 
 array_api_tests/test_special_cases.py::test_unary[signbit(isfinite(x_i) and x_i < 0) -> True]
 array_api_tests/test_special_cases.py::test_unary[signbit(x_i is NaN) -> False]
 array_api_tests/test_special_cases.py::test_unary[signbit(x_i is NaN) -> True]
-array_api_tests/test_special_cases.py::test_unary[sign((x_i is -0 or x_i == +0)) -> 0]
 array_api_tests/test_special_cases.py::test_unary[sin((x_i is +infinity or x_i == -infinity)) -> NaN]
 array_api_tests/test_special_cases.py::test_unary[sqrt(x_i < 0) -> NaN]
 array_api_tests/test_special_cases.py::test_unary[tan((x_i is +infinity or x_i == -infinity)) -> NaN]

--- a/sparse/tests/conftest.py
+++ b/sparse/tests/conftest.py
@@ -2,8 +2,23 @@ import sparse
 
 import pytest
 
+import numpy as np
+
 
 @pytest.fixture(scope="session", params=[sparse.BackendType.Numba, sparse.BackendType.Finch])
 def backend(request):
     with sparse.Backend(backend=request.param):
         yield request.param
+
+
+@pytest.fixture(scope="module")
+def graph():
+    return np.array(
+        [
+            [0, 1, 1, 0, 0],
+            [0, 0, 1, 0, 1],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1],
+            [0, 1, 0, 1, 0],
+        ]
+    )

--- a/sparse/tests/test_backends.py
+++ b/sparse/tests/test_backends.py
@@ -93,7 +93,7 @@ def test_scipy_inv(backend, format, order):
 
 
 @pytest.mark.skip(reason="https://github.com/scipy/scipy/pull/20759")
-@pytest.mark.parametrize("format, order", [("coo", "C")])
+@pytest.mark.parametrize("format, order", [("csc", "F"), ("csr", "C"), ("coo", "F"), ("coo", "C")])
 def test_scipy_norm(backend, format, order):
     x = np.eye(10, order=order) * 2
     x_pydata = sparse.asarray(x, format=format)
@@ -104,7 +104,7 @@ def test_scipy_norm(backend, format, order):
 
 
 @pytest.mark.skip(reason="https://github.com/scipy/scipy/pull/20759")
-@pytest.mark.parametrize("format, order", [("coo", "C")])
+@pytest.mark.parametrize("format, order", [("csc", "F"), ("csr", "C"), ("coo", "F"), ("coo", "C")])
 def test_scipy_lsqr(backend, format, order):
     x = np.eye(10, order=order) * 2
     y = np.ones((10, 1), order=order)
@@ -116,7 +116,7 @@ def test_scipy_lsqr(backend, format, order):
 
 
 @pytest.mark.skip(reason="https://github.com/scipy/scipy/pull/20759")
-@pytest.mark.parametrize("format, order", [("coo", "C")])
+@pytest.mark.parametrize("format, order", [("csc", "F"), ("csr", "C"), ("coo", "F"), ("coo", "C")])
 def test_scipy_eigs(backend, format, order):
     x = np.eye(10, order=order) * 2
     x_pydata = sparse.asarray(x, format=format)
@@ -127,7 +127,10 @@ def test_scipy_eigs(backend, format, order):
     assert_almost_equal(actual_vals, expected_vals)
 
 
-@pytest.mark.parametrize("matrix_fn, format, order", [(sps.csc_matrix, "csc", "F")])
+@pytest.mark.parametrize(
+    "matrix_fn, format, order",
+    [(sps.csc_matrix, "csc", "F"), (sps.csr_matrix, "csr", "C"), (sps.coo_matrix, "coo", "F")],
+)
 def test_scipy_connected_components(backend, graph, matrix_fn, format, order):
     graph = matrix_fn(np.array(graph, order=order))
     sp_graph = sparse.asarray(graph, format=format)
@@ -138,7 +141,10 @@ def test_scipy_connected_components(backend, graph, matrix_fn, format, order):
     assert_equal(actual_labels, expected_labels)
 
 
-@pytest.mark.parametrize("matrix_fn, format, order", [(sps.csc_matrix, "csc", "F")])
+@pytest.mark.parametrize(
+    "matrix_fn, format, order",
+    [(sps.csc_matrix, "csc", "F"), (sps.csr_matrix, "csr", "C"), (sps.coo_matrix, "coo", "F")],
+)
 def test_scipy_laplacian(backend, graph, matrix_fn, format, order):
     graph = matrix_fn(np.array(graph, order=order))
     sp_graph = sparse.asarray(graph, format=format)
@@ -148,7 +154,7 @@ def test_scipy_laplacian(backend, graph, matrix_fn, format, order):
     assert_equal(actual_lap.todense(), expected_lap.toarray())
 
 
-@pytest.mark.parametrize("matrix_fn, format, order", [(sps.csc_matrix, "csc", "F")])
+@pytest.mark.parametrize("matrix_fn, format, order", [(sps.csc_matrix, "csc", "F"), (sps.csr_matrix, "csr", "C")])
 def test_scipy_shortest_path(backend, graph, matrix_fn, format, order):
     graph = matrix_fn(np.array(graph, order=order))
     sp_graph = sparse.asarray(graph, format=format)
@@ -159,7 +165,10 @@ def test_scipy_shortest_path(backend, graph, matrix_fn, format, order):
     assert_equal(actual_predecessors, expected_predecessors)
 
 
-@pytest.mark.parametrize("matrix_fn, format, order", [(sps.csc_matrix, "csc", "F")])
+@pytest.mark.parametrize(
+    "matrix_fn, format, order",
+    [(sps.csc_matrix, "csc", "F"), (sps.csr_matrix, "csr", "C"), (sps.coo_matrix, "coo", "F")],
+)
 def test_scipy_breadth_first_tree(backend, graph, matrix_fn, format, order):
     graph = matrix_fn(np.array(graph, order=order))
     sp_graph = sparse.asarray(graph, format=format)
@@ -169,7 +178,10 @@ def test_scipy_breadth_first_tree(backend, graph, matrix_fn, format, order):
     assert_equal(actual_bft.todense(), expected_bft.toarray())
 
 
-@pytest.mark.parametrize("matrix_fn, format, order", [(sps.csc_matrix, "csc", "F")])
+@pytest.mark.parametrize(
+    "matrix_fn, format, order",
+    [(sps.csc_matrix, "csc", "F"), (sps.csr_matrix, "csr", "C"), (sps.coo_matrix, "coo", "F")],
+)
 def test_scipy_dijkstra(backend, graph, matrix_fn, format, order):
     graph = matrix_fn(np.array(graph, order=order))
     sp_graph = sparse.asarray(graph, format=format)
@@ -179,7 +191,10 @@ def test_scipy_dijkstra(backend, graph, matrix_fn, format, order):
     assert_equal(actual_dist_matrix, expected_dist_matrix)
 
 
-@pytest.mark.parametrize("matrix_fn, format, order", [(sps.csc_matrix, "csc", "F")])
+@pytest.mark.parametrize(
+    "matrix_fn, format, order",
+    [(sps.csc_matrix, "csc", "F"), (sps.csr_matrix, "csr", "C"), (sps.coo_matrix, "coo", "F")],
+)
 def test_scipy_minimum_spanning_tree(backend, graph, matrix_fn, format, order):
     graph = matrix_fn(np.array(graph, order=order))
     sp_graph = sparse.asarray(graph, format=format)


### PR DESCRIPTION
Hi @hameerabbasi,

Here's a PR that contains:
- Moved `test_unary[sign((x_i is -0 or x_i == +0)) -> 0]` to skips as this test is now flaky (it correctly failed in the PR but I see in the main branch it succeeded causing XPASS, so I guess `--derandomize` didn't get rid of all randomness)
- `test_scipy_sparse_csgraph_dispatch` with `scipy.sparse.csgraph` tests
- commented out a few linalg tests that require https://github.com/scipy/scipy/pull/20759 (and a new scipy release)
- `test_scikit_learn_dispatch`, skipped for now as it requires https://github.com/scikit-learn/scikit-learn/pull/29031