### PR TITLE
Support direct Numba imports

### DIFF
--- a/sparse/__init__.py
+++ b/sparse/__init__.py
@@ -43,6 +43,16 @@ class Backend:
             raise ValueError(f"Invalid backend identifier: {backend}")
         return backend_module
 
+    @staticmethod
+    def import_names_into_namespace():
+        backend = backend_var.get()
+        if backend == BackendType.Numba:
+            exec("from .numba_backend import *")
+        elif backend == BackendType.Finch:
+            exec("from .finch_backend import *")
+        else:
+            raise ValueError(f"Invalid backend identifier: {backend}")
+
 
 def __getattr__(attr):
     if attr == "numba_backend":
@@ -55,3 +65,6 @@ def __getattr__(attr):
         return backend_module
 
     return getattr(Backend.get_backend_module(), attr)
+
+
+Backend.import_names_into_namespace()

--- a/sparse/__init__.py
+++ b/sparse/__init__.py
@@ -43,16 +43,6 @@ class Backend:
             raise ValueError(f"Invalid backend identifier: {backend}")
         return backend_module
 
-    @staticmethod
-    def import_names_into_namespace():
-        backend = backend_var.get()
-        if backend == BackendType.Numba:
-            exec("from .numba_backend import *")
-        elif backend == BackendType.Finch:
-            exec("from .finch_backend import *")
-        else:
-            raise ValueError(f"Invalid backend identifier: {backend}")
-
 
 def __getattr__(attr):
     if attr == "numba_backend":
@@ -67,4 +57,5 @@ def __getattr__(attr):
     return getattr(Backend.get_backend_module(), attr)
 
 
-Backend.import_names_into_namespace()
+if backend_var.get() == BackendType.Numba:
+    from .numba_backend import COO, GCXS, SparseArray, elemwise  # noqa: F401

--- a/sparse/tests/test_backends.py
+++ b/sparse/tests/test_backends.py
@@ -220,3 +220,10 @@ def test_scikit_learn_dispatch(backend, graph, matrix_fn, format, order):
     expected_labels = neigh.fit_predict(graph)
 
     assert_equal(actual_labels, expected_labels)
+
+
+
+def test_numba_direct_imports(backend):
+    if backend == sparse.BackendType.Finch:
+        pytest.skip("Finch not tested")
+    from sparse import COO, GCXS, SparseArray, elemwise  # noqa: F401

--- a/sparse/tests/test_backends.py
+++ b/sparse/tests/test_backends.py
@@ -222,7 +222,6 @@ def test_scikit_learn_dispatch(backend, graph, matrix_fn, format, order):
     assert_equal(actual_labels, expected_labels)
 
 
-
 def test_numba_direct_imports(backend):
     if backend == sparse.BackendType.Finch:
         pytest.skip("Finch not tested")


### PR DESCRIPTION
Hi @hameerabbasi,

I noticed that downstream libraries use direct imports for some Numba objects, e.g.: `from sparse import COO` (https://github.com/search?q=%22from+sparse+import%22+language%3APython&type=code). Since we will be releasing version `0.16.0` in some time, we need to support this kind of import to avoid disruption to users.