### PR TITLE
Fix 1D return dtype in argmax/argmin

### DIFF
--- a/ci/Numba-array-api-xfails.txt
+++ b/ci/Numba-array-api-xfails.txt
@@ -44,8 +44,6 @@ array_api_tests/test_indexing_functions.py::test_take
 array_api_tests/test_linalg.py::test_vecdot
 array_api_tests/test_operators_and_elementwise_functions.py::test_ceil
 array_api_tests/test_operators_and_elementwise_functions.py::test_trunc
-array_api_tests/test_searching_functions.py::test_argmax
-array_api_tests/test_searching_functions.py::test_argmin
 array_api_tests/test_set_functions.py::test_unique_all
 array_api_tests/test_set_functions.py::test_unique_inverse
 array_api_tests/test_signatures.py::test_func_signature[unique_all]

--- a/sparse/numba_backend/_coo/common.py
+++ b/sparse/numba_backend/_coo/common.py
@@ -1456,7 +1456,7 @@ def _compute_minmax_args(
             if not found:
                 result_data.append(current_coord + 1)
 
-    return (result_indices, result_data)
+    return (result_indices, np.array(result_data, dtype=np.intp))
 
 
 def _arg_minmax_common(


### PR DESCRIPTION
Hi @hameerabbasi,

This PR fixes `argmin`/`argmax` when input is 1D and result is a fill value. To reproduce:

```python
sparse.argmax(sparse.asarray(np.arange(1), dtype=np.uint8)).dtype  # defaulted to `float64` as `np.array([]).dtype` is `float64`. Now it's `intp`
```