### PR TITLE
docs: Added `sparse.max` docstring

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -53,7 +53,7 @@ Please adhere to the following guidelines:
 
 1. Start your pull request title with a [conventional commit](https://www.conventionalcommits.org/) tag. This helps us add your contribution to the right section of the changelog. We use "Type" from the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).<br>
     TLDR:<br>
-    The PR title should start with any of these abbreviatons: `build`, `chore`, `ci`, `depr`,
+    The PR title should start with any of these abbreviations: `build`, `chore`, `ci`, `depr`,
     `docs`, `feat`, `fix`, `perf`, `refactor`, `release`, `test`. Add a `!`at the end, if it is a breaking change. For example `refactor!`.
 2. This text will end up in the changelog.
 3. Please follow the instructions in the pull request form and submit.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ markdown_extensions:
   - pymdownx.superfences
   - codehilite
   - toc:
-      toc_depth: 2
+      toc_depth: 3
   - pymdownx.arithmatex: # To display math content with KaTex
       generic: true
   - attr_list # To be able to link to a header on another page, use grids

--- a/sparse/numba_backend/_common.py
+++ b/sparse/numba_backend/_common.py
@@ -2114,6 +2114,33 @@ def permute_dims(x, /, axes=None):
 
 
 def max(x, /, *, axis=None, keepdims=False):
+    """
+    Calculates the maximum value of the input array ``x``.
+
+    Parameters
+    ----------
+    x: array
+        input array of a real-valued data type.
+    axis: Optional[Union[int, Tuple[int, ...]]]
+        axis or axes along which maximum values are computed.
+        By default, the maximum value are computed over the entire array.
+        If a tuple of integers, maximum values are computed over multiple axes. Default: ``None``.
+    keepdims: bool
+        If ``True``, the reduced axes (dimensions) are included in the result as singleton dimensions.
+        Accordingly, the result is compatible with the input array.
+        Otherwise, if ``False``, the reduced axes (dimensions) must not be included in the result. Default: ``False``.
+
+    Returns
+    -------
+    out: array
+        if the maximum value was computed over the entire array, a zero-dimensional array containing the maximum value.
+        Otherwise, a non-zero-dimensional array containing the maximum values.
+        The returned array has the same data type as ``x``.
+
+    Special Cases
+    -------------
+    For floating-point operands, if ``x_i`` is ``NaN``, the maximum value is ``NaN`` (i.e., ``NaN`` values propagate).
+    """
     return x.max(axis=axis, keepdims=keepdims)
 
 

--- a/sparse/numba_backend/_common.py
+++ b/sparse/numba_backend/_common.py
@@ -10,6 +10,7 @@ from numba import literal_unroll
 
 import numpy as np
 
+from ._coo.core import COO
 from ._coo.common import asCOO
 from ._sparse_array import SparseArray
 from ._utils import (
@@ -2143,8 +2144,6 @@ def max(x, /, *, axis=None, keepdims=False):
 
     Examples
     --------
-    >>> import numpy as np
-    >>> import sparse
     >>> a = sparse.COO.from_numpy(np.array([[0, 1], [2, 0]]))
     >>> o = sparse.max(a, axis=1)
     >>> o.todense()

--- a/sparse/numba_backend/_common.py
+++ b/sparse/numba_backend/_common.py
@@ -2140,6 +2140,15 @@ def max(x, /, *, axis=None, keepdims=False):
     Special Cases
     -------------
     For floating-point operands, if ``x_i`` is ``NaN``, the maximum value is ``NaN`` (i.e., ``NaN`` values propagate).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import sparse
+    >>> a = sparse.COO.from_numpy(np.array([[0, 1], [2, 0]]))
+    >>> o = sparse.max(a, axis=1)
+    >>> o.todense()
+    array([1, 2])
     """
     return x.max(axis=axis, keepdims=keepdims)
 

--- a/sparse/numba_backend/_common.py
+++ b/sparse/numba_backend/_common.py
@@ -10,7 +10,6 @@ from numba import literal_unroll
 
 import numpy as np
 
-from ._coo.core import COO
 from ._coo.common import asCOO
 from ._sparse_array import SparseArray
 from ._utils import (


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/pydata/sparse/blob/main/docs/contributing.md

Your PR title should start with any of these abbreviatons: `build`, `chore`, `ci`, `depr`, `docs`, `feat`, `fix`, `perf`, `refactor`, `release`, `test`. Add a `!`at the end, if it is a breaking change.
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] 🪄 Feature
- [ ] 🐞 Bug Fix
- [ ] 🔧 Optimization
- [x] 📚 Documentation
- [ ] 🧪 Test
- [ ] 🛠️ Other

## Related issues

- Related issue #
- Closes #

## Checklist

- [x] Code follows style guide
- [ ] Tests added
- [ ] Documented the changes

***

## Please explain your changes below.

- Took docstring from API array, but did some changes. Please tell me if this is OK.

- Modified table of content to 3, to show the functions and attributes to the right of the screen. (With 2, there is no way to find the members of a class other than scroll down). 

