### PR TITLE
bld: Upgrade LLVM version to `19.1.0.rc3`

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - mlir-python-bindings
+  - conda-forge/label/llvm_rc::mlir-python-bindings==19.1.0.rc3
   - pip:
     - finch-tensor >=0.1.31
     - pytest-codspeed

--- a/sparse/mlir_backend/__init__.py
+++ b/sparse/mlir_backend/__init__.py
@@ -3,7 +3,7 @@ try:
 except ModuleNotFoundError as e:
     raise ImportError(
         "MLIR Python bindings not installed. Run "
-        "`conda install conda-forge::mlir-python-bindings` "
+        "`conda install conda-forge/label/llvm_rc::mlir-python-bindings` "
         "to enable MLIR backend."
     ) from e
 

--- a/sparse/mlir_backend/_core.py
+++ b/sparse/mlir_backend/_core.py
@@ -1,4 +1,5 @@
 import ctypes
+import ctypes.util
 import os
 import pathlib
 

--- a/sparse/mlir_backend/_ops.py
+++ b/sparse/mlir_backend/_ops.py
@@ -38,15 +38,15 @@ def get_add_module(a_tensor_type, b_tensor_type, out_tensor_type, dtype: type[DT
                     with ir.InsertionPoint(overlap):
                         arg0, arg1 = overlap.arguments
                         overlap_res = arith_op(arg0, arg1)
-                        sparse_tensor.YieldOp(result=overlap_res)
+                        sparse_tensor.YieldOp([overlap_res])
                     left_region = res.regions[1].blocks.append(dtype)
                     with ir.InsertionPoint(left_region):
                         (arg0,) = left_region.arguments
-                        sparse_tensor.YieldOp(result=arg0)
+                        sparse_tensor.YieldOp([arg0])
                     right_region = res.regions[2].blocks.append(dtype)
                     with ir.InsertionPoint(right_region):
                         (arg0,) = right_region.arguments
-                        sparse_tensor.YieldOp(result=arg0)
+                        sparse_tensor.YieldOp([arg0])
                     linalg.YieldOp([res])
                 return generic_op.result
 


### PR DESCRIPTION
Hi @hameerabbasi,

This PR updates codebase to LLVM `19.1.0.rc3` compatible version.
