### PR TITLE
MNT: Refactor MLIR constructors

### DIFF
--- a/sparse/mlir_backend/_core.py
+++ b/sparse/mlir_backend/_core.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 
 from mlir.ir import Context
+from mlir.passmanager import PassManager
 
 DEBUG = bool(int(os.environ.get("DEBUG", "0")))
 CWD = pathlib.Path(".")
@@ -15,3 +16,5 @@ libc.free.restype = None
 
 # TODO: remove global state
 ctx = Context()
+
+pm = PassManager.parse("builtin.module(sparsifier{create-sparse-deallocs=1})", context=ctx)

--- a/sparse/mlir_backend/_ops.py
+++ b/sparse/mlir_backend/_ops.py
@@ -6,11 +6,16 @@ from mlir import ir
 from mlir.dialects import arith, func, linalg, sparse_tensor, tensor
 
 from ._constructors import Tensor
-from ._core import CWD, DEBUG, MLIR_C_RUNNER_UTILS, ctx
+from ._core import CWD, DEBUG, MLIR_C_RUNNER_UTILS, ctx, pm
 from ._dtypes import DType, FloatingDType
 
 
-def get_add_module(a_tensor_type, b_tensor_type, out_tensor_type, dtype: type[DType]):
+def get_add_module(
+    a_tensor_type: ir.RankedTensorType,
+    b_tensor_type: ir.RankedTensorType,
+    out_tensor_type: ir.RankedTensorType,
+    dtype: type[DType],
+) -> ir.Module:
     with ir.Location.unknown(ctx):
         module = ir.Module.create()
         # TODO: add support for complex dialect/dtypes
@@ -53,9 +58,7 @@ def get_add_module(a_tensor_type, b_tensor_type, out_tensor_type, dtype: type[DT
         add.func_op.attributes["llvm.emit_c_interface"] = ir.UnitAttr.get()
         if DEBUG:
             (CWD / "add_module.mlir").write_text(str(module))
-        pm = mlir.passmanager.PassManager.parse("builtin.module(sparsifier{create-sparse-deallocs=1})")
         pm.run(module.operation)
-
         if DEBUG:
             (CWD / "add_module_opt.mlir").write_text(str(module))
 

--- a/sparse/mlir_backend/tests/test_simple.py
+++ b/sparse/mlir_backend/tests/test_simple.py
@@ -1,3 +1,4 @@
+import math
 import typing
 
 import sparse
@@ -72,12 +73,21 @@ def generate_sampler(dtype: np.dtype, rng: np.random.Generator) -> typing.Callab
 
 
 @parametrize_dtypes
+@pytest.mark.parametrize("shape", [(100,), (10, 20), (5, 10, 20)])
+def test_dense_format(dtype, shape):
+    data = np.arange(math.prod(shape), dtype=dtype)
+    tensor = sparse.asarray(data)
+    actual = tensor.to_scipy_sparse()
+    np.testing.assert_equal(actual, data)
+
+
+@parametrize_dtypes
 def test_constructors(rng, dtype):
     SHAPE = (10, 5)
     DENSITY = 0.5
     sampler = generate_sampler(dtype, rng)
     a = sps.random_array(SHAPE, density=DENSITY, format="csr", dtype=dtype, random_state=rng, data_sampler=sampler)
-    c = np.arange(50, dtype=dtype).reshape((10, 5))
+    c = np.arange(math.prod(SHAPE), dtype=dtype).reshape(SHAPE)
     d = sps.random_array(SHAPE, density=DENSITY, format="coo", dtype=dtype, random_state=rng, data_sampler=sampler)
 
     a_tensor = sparse.asarray(a)


### PR DESCRIPTION
Hi @hameerabbasi,

This PR refactors MLIR Tensor constructors and removes some boilerplate by introducing: `BaseFormat` that defines interface for implementing Dense variants, COO, CSR (present currently), and allows to implement CSC, CSF, and others in the future.

