### PR TITLE
test: working on benchmarks with `Finch` as backend

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -25,4 +25,9 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v3
         with:
-          run: pytest benchmarks/ --codspeed
+          run: SPARSE_BACKEND=Numba pytest benchmarks/ --codspeed
+
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v3
+        with:
+          run: SPARSE_BACKEND=Finch pytest benchmarks/ --codspeed

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,10 +1,25 @@
 import pytest
-
+import os
+import sparse
 
 @pytest.fixture
 def seed(scope="session"):
     return 42
 
+
+def get_backend_id(param):
+    backend = param
+    return f"{backend=}"
+
+@pytest.fixture(params=[sparse._BACKEND], autouse=True, ids=get_backend_id)
+def backend(request):
+
+    return request.param
+    
+
+@pytest.fixture
+def min_size(scope="session"):
+    return 100
 
 @pytest.fixture
 def max_size(scope="session"):

--- a/benchmarks/test_benchmark_coo.py
+++ b/benchmarks/test_benchmark_coo.py
@@ -13,17 +13,21 @@ DENSITY = 0.01
 def format_id(format):
     return f"{format=}"
 
-
 @pytest.mark.parametrize("format", ["coo", "gcxs"])
-def test_matmul(benchmark, sides, format, seed, max_size, ids=format_id):
+def test_matmul(benchmark, sides, seed, format, backend, min_size, max_size, ids=format_id):
+    #if backend == sparse._BackendType.Finch:
+    #    pytest.skip()
+    
     m, n, p = sides
-
-    if m * n >= max_size or n * p >= max_size:
+  
+    if m * n >= max_size or n * p >= max_size or m * n <= min_size or n * p <= min_size:
         pytest.skip()
-
+    
     rng = np.random.default_rng(seed=seed)
     x = sparse.random((m, n), density=DENSITY, format=format, random_state=rng)
     y = sparse.random((n, p), density=DENSITY, format=format, random_state=rng)
+    
+    if hasattr(sparse, "compiled"): operator.matmul = sparse.compiled(operator.matmul)
 
     x @ y  # Numba compilation
 
@@ -52,6 +56,9 @@ def elemwise_args(request, seed, max_size):
 @pytest.mark.parametrize("f", [operator.add, operator.mul])
 def test_elemwise(benchmark, f, elemwise_args):
     x, y = elemwise_args
+
+    if hasattr(sparse, "compiled"): f = sparse.compiled(f)
+    
     f(x, y)
 
     @benchmark


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/pydata/sparse/blob/main/docs/contributing.md

Your PR title should start with any of these abbreviatons: `build`, `chore`, `ci`, `depr`, `docs`, `feat`, `fix`, `perf`, `refactor`, `release`, `test`. Add a `!`at the end, if it is a breaking change.
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] 🪄 Feature
- [ ] 🐞 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📚 Documentation
- [x] 🧪 Test
- [ ] 🛠️ Other

## Related issues

- Related issue #
- Closes #

## Checklist

- [ ] Code follows style guide
- [ ] Tests added
- [ ] Documented the changes

***

## Please explain your changes below.
Only added `Finch` on `config.py` - (locally I see the names of the backend. But I'm not sure if this renders fine on CodSpeed).
Also, per Hameer instructions I need to see which tests fail with `Finch`. 
I would like to see if the change on `codspeed.yml` works like expected. 
Finally, I have only added the line `if hasattr(sparse, "compiled"): f = sparse.compiled(f)` to the first two benchmarks to make sure I correctly understood. 
