### PR TITLE
MNT: Move constructors to a direct style

### DIFF
--- a/sparse/mlir_backend/_common.py
+++ b/sparse/mlir_backend/_common.py
@@ -1,5 +1,7 @@
 import abc
+import ctypes
 import functools
+import weakref
 
 from mlir import ir
 
@@ -12,3 +14,23 @@ class MlirType(abc.ABC):
 
 def fn_cache(f, maxsize: int | None = None):
     return functools.wraps(f)(functools.lru_cache(maxsize=maxsize)(f))
+
+
+def _hold_self_ref_in_ret(fn):
+    @functools.wraps(fn)
+    def wrapped(self, *a, **kw):
+        ret = fn(self, *a, **kw)
+        _take_owneship(ret, self)
+        return ret
+
+    return wrapped
+
+
+def _take_owneship(owner, obj):
+    ptr = ctypes.py_object(obj)
+    ctypes.pythonapi.Py_IncRef(ptr)
+
+    def finalizer(ptr):
+        ctypes.pythonapi.Py_DecRef(ptr)
+
+    weakref.finalize(owner, finalizer, ptr)

--- a/sparse/mlir_backend/_constructors.py
+++ b/sparse/mlir_backend/_constructors.py
@@ -1,463 +1,199 @@
-import abc
 import ctypes
-import functools
-import typing
 import weakref
 
-import mlir.execution_engine
-import mlir.passmanager
+import mlir.runtime as rt
 from mlir import ir
-from mlir import runtime as rt
-from mlir.dialects import arith, bufferization, func, sparse_tensor, tensor
+from mlir.dialects import sparse_tensor
 
 import numpy as np
 import scipy.sparse as sps
 
 from ._common import fn_cache
-from ._core import CWD, DEBUG, MLIR_C_RUNNER_UTILS, ctx, pm
-from ._dtypes import DType, Index, asdtype
+from ._core import ctx, libc
+from ._dtypes import DType, asdtype
 
 
-def _hold_self_ref_in_ret(fn):
-    @functools.wraps(fn)
-    def wrapped(self, *a, **kw):
-        ptr = ctypes.py_object(self)
-        ctypes.pythonapi.Py_IncRef(ptr)
-        ret = fn(self, *a, **kw)
+def _take_owneship(owner, obj):
+    ptr = ctypes.py_object(obj)
+    ctypes.pythonapi.Py_IncRef(ptr)
 
-        def finalizer(ptr):
-            ctypes.pythonapi.Py_DecRef(ptr)
+    def finalizer(ptr):
+        ctypes.pythonapi.Py_DecRef(ptr)
 
-        weakref.finalize(ret, finalizer, ptr)
-        return ret
-
-    return wrapped
+    weakref.finalize(owner, finalizer, ptr)
 
 
-class Tensor:
-    def __init__(self, obj, module, tensor_type, disassemble_fn, values_dtype, index_dtype):
-        self.obj = obj
-        self.module = module
-        self.tensor_type = tensor_type
-        self.disassemble_fn = disassemble_fn
-        self.values_dtype = values_dtype
-        self.index_dtype = index_dtype
-
-    def __del__(self):
-        self.module.invoke("free_tensor", ctypes.pointer(self.obj))
-
-    @_hold_self_ref_in_ret
-    def to_scipy_sparse(self):
-        """
-        Returns scipy.sparse or ndarray
-        """
-        return self.disassemble_fn(
-            self.module,
-            self.obj,
-            self.tensor_type.shape,
-            self.values_dtype,
-            self.index_dtype,
-        )
+###########
+# Memrefs #
+###########
 
 
-class BaseFormat(abc.ABC):
-    @classmethod
-    @abc.abstractmethod
-    def get_format_str(cls) -> str:
-        raise NotImplementedError
-
-    @classmethod
-    @abc.abstractmethod
-    def get_levels(cls) -> tuple[sparse_tensor.LevelFormat, ...]:
-        raise NotImplementedError
-
-    @classmethod
-    @abc.abstractmethod
-    def get_ordering(cls) -> ir.AffineMap:
-        raise NotImplementedError
-
-    @classmethod
-    @abc.abstractmethod
-    def get_assemble_functions(
-        cls,
-        module: ir.Module,
-        tensor_shaped: ir.RankedTensorType,
-        values_dtype: type[DType],
-        index_dtype: type[DType],
-    ) -> tuple[typing.Callable, ...]:
-        raise NotImplementedError
-
-    @classmethod
-    @abc.abstractmethod
-    def assemble(cls, module: ir.Module, arr: np.ndarray | sps.sparray) -> ctypes.c_void_p:
-        raise NotImplementedError
-
-    @classmethod
-    @abc.abstractmethod
-    def disassemble(
-        cls,
-        module: ir.Module,
-        ptr: ctypes.c_void_p,
-        shape: list[int],
-        values_dtype: type[DType],
-        index_dtype: type[DType],
-    ) -> np.ndarray | sps.sparray:
-        raise NotImplementedError
-
-    @classmethod
-    @fn_cache
-    def get_module(
-        cls,
-        shape: tuple[int],
-        values_dtype: type[DType],
-        index_dtype: type[DType],
-    ) -> tuple[ir.Module, ir.RankedTensorType]:
-        with ir.Location.unknown(ctx):
-            module = ir.Module.create()
-            values_dtype = values_dtype.get_mlir_type()
-            index_dtype = index_dtype.get_mlir_type()
-            index_width = getattr(index_dtype, "width", 0)
-            levels = cls.get_levels()
-            ordering = cls.get_ordering()
-            encoding = sparse_tensor.EncodingAttr.get(levels, ordering, ordering, index_width, index_width)
-            tensor_shaped = ir.RankedTensorType.get(list(shape), values_dtype, encoding)
-
-            assemble, disassemble, free_tensor = cls.get_assemble_functions(
-                module, tensor_shaped, values_dtype, index_dtype
-            )
-
-            assemble.func_op.attributes["llvm.emit_c_interface"] = ir.UnitAttr.get()
-            disassemble.func_op.attributes["llvm.emit_c_interface"] = ir.UnitAttr.get()
-            free_tensor.func_op.attributes["llvm.emit_c_interface"] = ir.UnitAttr.get()
-            if DEBUG:
-                (CWD / f"{cls.get_format_str()}.mlir").write_text(str(module))
-            pm.run(module.operation)
-            if DEBUG:
-                (CWD / f"{cls.get_format_str()}_opt.mlir").write_text(str(module))
-
-        module = mlir.execution_engine.ExecutionEngine(module, opt_level=2, shared_libs=[MLIR_C_RUNNER_UTILS])
-        return (module, tensor_shaped)
+@fn_cache
+def get_nd_memref_descr(rank: int, dtype: type[DType]) -> type:
+    return rt.make_nd_memref_descriptor(rank, dtype.to_ctype())
 
 
-class AbstractDenseFormat(BaseFormat):
-    @classmethod
-    def get_assemble_functions(
-        cls,
-        module: ir.Module,
-        tensor_shaped: ir.RankedTensorType,
-        values_dtype: type[DType],
-        index_dtype: type[DType],
-    ) -> tuple[typing.Callable, ...]:
-        tensor_1d = tensor.RankedTensorType.get([ir.ShapedType.get_dynamic_size()], values_dtype)
-        with ir.InsertionPoint(module.body):
+def numpy_to_ranked_memref(arr: np.ndarray) -> ctypes.Structure:
+    memref = rt.get_ranked_memref_descriptor(arr)
+    memref_descr = get_nd_memref_descr(arr.ndim, asdtype(arr.dtype))
+    # Required due to ctypes type checks
+    return memref_descr(
+        allocated=memref.allocated,
+        aligned=memref.aligned,
+        offset=memref.offset,
+        shape=memref.shape,
+        strides=memref.strides,
+    )
 
-            @func.FuncOp.from_py_func(tensor_1d)
-            def assemble(data):
-                return sparse_tensor.assemble(tensor_shaped, [], data)
 
-            @func.FuncOp.from_py_func(tensor_shaped)
-            def disassemble(tensor_shaped):
-                data = tensor.EmptyOp([arith.constant(ir.IndexType.get(), 0)], values_dtype)
-                data, data_len = sparse_tensor.disassemble(
-                    [],
-                    tensor_1d,
-                    [],
-                    index_dtype,
-                    tensor_shaped,
-                    [],
-                    data,
-                )
-                return data, data_len
+def ranked_memref_to_numpy(ref: ctypes.Structure) -> np.ndarray:
+    return rt.ranked_memref_to_numpy([ref])
 
-            @func.FuncOp.from_py_func(tensor_shaped)
-            def free_tensor(tensor_shaped):
-                bufferization.dealloc_tensor(tensor_shaped)
 
-        return assemble, disassemble, free_tensor
+def freeme(obj: ctypes.Structure) -> None:
+    # TODO: I think there's still a memory leak
+    libc.free(ctypes.cast(obj.allocated, ctypes.c_void_p))
 
-    @classmethod
-    def assemble(cls, module: ir.Module, arr: np.ndarray) -> ctypes.c_void_p:
-        data = rt.get_ranked_memref_descriptor(arr)
-        out = ctypes.c_void_p()
-        module.invoke(
-            "assemble",
-            ctypes.pointer(ctypes.pointer(data)),
-            ctypes.pointer(out),
-        )
-        return out
 
-    @classmethod
-    def disassemble(
-        cls,
-        module: ir.Module,
-        ptr: ctypes.c_void_p,
-        shape: list[int],
-        values_dtype: type[DType],
-        index_dtype: type[DType],
-    ) -> np.ndarray:
-        class Dense(ctypes.Structure):
-            _fields_ = [
-                ("data", rt.make_nd_memref_descriptor(1, values_dtype.to_ctype())),
-                ("data_len", np.ctypeslib.c_intp),
+###########
+# Formats #
+###########
+
+
+@fn_cache
+def get_csr_class(values_dtype: type[DType], index_dtype: type[DType]) -> type:
+    class Csr(ctypes.Structure):
+        _fields_ = [
+            ("indptr", get_nd_memref_descr(1, index_dtype)),
+            ("indices", get_nd_memref_descr(1, index_dtype)),
+            ("data", get_nd_memref_descr(1, values_dtype)),
+        ]
+        dtype = values_dtype
+        _index_dtype = index_dtype
+
+        @classmethod
+        def from_sps(cls, arr: sps.csr_array) -> "Csr":
+            indptr = numpy_to_ranked_memref(arr.indptr)
+            indices = numpy_to_ranked_memref(arr.indices)
+            data = numpy_to_ranked_memref(arr.data)
+            return cls(indptr=indptr, indices=indices, data=data)
+
+        def to_sps(self, shape: tuple[int, ...]) -> sps.csr_array:
+            pos = ranked_memref_to_numpy(self.indptr)
+            crd = ranked_memref_to_numpy(self.indices)
+            data = ranked_memref_to_numpy(self.data)
+            return sps.csr_array((data, crd, pos), shape=shape)
+
+        def to_module_arg(self) -> list:
+            return [
+                ctypes.pointer(ctypes.pointer(self.indptr)),
+                ctypes.pointer(ctypes.pointer(self.indices)),
+                ctypes.pointer(ctypes.pointer(self.data)),
             ]
 
-            def to_np(self) -> np.ndarray:
-                data = rt.ranked_memref_to_numpy([self.data])[: self.data_len]
-                return data.reshape(shape)
+        @classmethod
+        @fn_cache
+        def get_tensor_definition(cls, shape: tuple[int, ...]) -> ir.RankedTensorType:
+            with ir.Location.unknown(ctx):
+                values_dtype = cls.dtype.get_mlir_type()
+                index_dtype = cls._index_dtype.get_mlir_type()
+                index_width = getattr(index_dtype, "width", 0)
+                levels = (sparse_tensor.LevelFormat.dense, sparse_tensor.LevelFormat.compressed)
+                ordering = ir.AffineMap.get_permutation([0, 1])
+                encoding = sparse_tensor.EncodingAttr.get(levels, ordering, ordering, index_width, index_width)
+                return ir.RankedTensorType.get(list(shape), values_dtype, encoding)
 
-        arr = Dense()
-        module.invoke(
-            "disassemble",
-            ctypes.pointer(ctypes.pointer(arr)),
-            ctypes.pointer(ptr),
-        )
-        return arr.to_np()
-
-
-class VectorFormat(AbstractDenseFormat):
-    @classmethod
-    def get_format_str(cls) -> str:
-        return "sparse_vector_format"
-
-    @classmethod
-    def get_levels(cls) -> tuple[sparse_tensor.LevelFormat, ...]:
-        return (sparse_tensor.LevelFormat.dense,)
-
-    @classmethod
-    def get_ordering(cls) -> ir.AffineMap:
-        return ir.AffineMap.get_permutation([0])
+    return Csr
 
 
-class Dense2DFormat(AbstractDenseFormat):
-    @classmethod
-    def get_format_str(cls) -> str:
-        return "dense_2d_format"
+@fn_cache
+def get_coo_class(values_dtype: type[DType], index_dtype: type[DType]) -> type:
+    class Coo(ctypes.Structure):
+        _fields_ = [
+            ("pos", get_nd_memref_descr(1, index_dtype)),
+            ("coords", get_nd_memref_descr(2, index_dtype)),
+            ("data", get_nd_memref_descr(1, values_dtype)),
+        ]
+        dtype = values_dtype
+        _index_dtype = index_dtype
 
-    @classmethod
-    def get_levels(cls) -> tuple[sparse_tensor.LevelFormat, ...]:
-        return (sparse_tensor.LevelFormat.dense,) * 2
+        @classmethod
+        def from_sps(cls, arr: sps.csr_array) -> "Coo":
+            np_pos = np.array([0, arr.size], dtype=index_dtype.np_dtype)
+            np_coords = np.stack(arr.coords, axis=1, dtype=index_dtype.np_dtype)
+            pos = numpy_to_ranked_memref(np_pos)
+            coords = numpy_to_ranked_memref(np_coords)
+            data = numpy_to_ranked_memref(arr.data)
 
-    @classmethod
-    def get_ordering(cls) -> ir.AffineMap:
-        return ir.AffineMap.get_permutation([0, 1])
+            coo_instance = cls(pos=pos, coords=coords, data=data)
+            _take_owneship(coo_instance, np_pos)
+            _take_owneship(coo_instance, np_coords)
 
+            return coo_instance
 
-class Dense3DFormat(AbstractDenseFormat):
-    @classmethod
-    def get_format_str(cls) -> str:
-        return "dense_3d_format"
+        def to_sps(self, shape: tuple[int, ...]) -> sps.csr_array:
+            pos = ranked_memref_to_numpy(self.pos)
+            coords = ranked_memref_to_numpy(self.coords)[pos[0] : pos[1]]
+            data = ranked_memref_to_numpy(self.data)
+            return sps.coo_array((data, coords.T), shape=shape)
 
-    @classmethod
-    def get_levels(cls) -> tuple[sparse_tensor.LevelFormat, ...]:
-        return (sparse_tensor.LevelFormat.dense,) * 3
-
-    @classmethod
-    def get_ordering(cls) -> ir.AffineMap:
-        return ir.AffineMap.get_permutation([0, 2, 3])
-
-
-class COOFormat(BaseFormat):
-    @classmethod
-    def get_format_str(cls) -> str:
-        return "coo_format"
-
-    @classmethod
-    def get_levels(cls) -> tuple[sparse_tensor.LevelFormat, ...]:
-        compressed_lvl = sparse_tensor.EncodingAttr.build_level_type(
-            sparse_tensor.LevelFormat.compressed, [sparse_tensor.LevelProperty.non_unique]
-        )
-        return (compressed_lvl, sparse_tensor.LevelFormat.singleton)
-
-    @classmethod
-    def get_ordering(cls) -> ir.AffineMap:
-        return ir.AffineMap.get_permutation([0, 1])
-
-    @classmethod
-    def get_assemble_functions(
-        cls,
-        module: ir.Module,
-        tensor_shaped: ir.RankedTensorType,
-        values_dtype: type[DType],
-        index_dtype: type[DType],
-    ) -> tuple[typing.Callable, ...]:
-        tensor_1d_index = tensor.RankedTensorType.get([ir.ShapedType.get_dynamic_size()], index_dtype)
-        tensor_2d_index = tensor.RankedTensorType.get(
-            [ir.ShapedType.get_dynamic_size(), tensor_shaped.rank], index_dtype
-        )
-        tensor_1d_values = tensor.RankedTensorType.get([ir.ShapedType.get_dynamic_size()], values_dtype)
-        with ir.InsertionPoint(module.body):
-
-            @func.FuncOp.from_py_func(tensor_1d_index, tensor_2d_index, tensor_1d_values)
-            def assemble(pos, index, values):
-                return sparse_tensor.assemble(tensor_shaped, (pos, index), values)
-
-            @func.FuncOp.from_py_func(tensor_shaped)
-            def disassemble(tensor_shaped):
-                nse = sparse_tensor.number_of_entries(tensor_shaped)
-                pos = tensor.EmptyOp([arith.constant(ir.IndexType.get(), 2)], index_dtype)
-                index = tensor.EmptyOp([nse, 2], index_dtype)
-                values = tensor.EmptyOp([nse], values_dtype)
-                pos, index, values, pos_len, index_len, values_len = sparse_tensor.disassemble(
-                    (tensor_1d_index, tensor_2d_index),
-                    tensor_1d_values,
-                    (index_dtype, index_dtype),
-                    index_dtype,
-                    tensor_shaped,
-                    (pos, index),
-                    values,
-                )
-                return pos, index, values, pos_len, index_len, values_len
-
-            @func.FuncOp.from_py_func(tensor_shaped)
-            def free_tensor(tensor_shaped):
-                bufferization.dealloc_tensor(tensor_shaped)
-
-        return assemble, disassemble, free_tensor
-
-    @classmethod
-    def assemble(cls, module: ir.Module, arr: sps.coo_array) -> ctypes.c_void_p:
-        out = ctypes.c_void_p()
-        index_dtype = arr.coords[0].dtype
-        module.invoke(
-            "assemble",
-            ctypes.pointer(ctypes.pointer(rt.get_ranked_memref_descriptor(np.array([0, arr.size], dtype=index_dtype)))),
-            ctypes.pointer(
-                ctypes.pointer(rt.get_ranked_memref_descriptor(np.stack(arr.coords, axis=1, dtype=index_dtype)))
-            ),
-            ctypes.pointer(ctypes.pointer(rt.get_ranked_memref_descriptor(arr.data))),
-            ctypes.pointer(out),
-        )
-        return out
-
-    @classmethod
-    def disassemble(
-        cls,
-        module: ir.Module,
-        ptr: ctypes.c_void_p,
-        shape: list[int],
-        values_dtype: type[DType],
-        index_dtype: type[DType],
-    ) -> sps.coo_array:
-        class Coo(ctypes.Structure):
-            _fields_ = [
-                ("pos", rt.make_nd_memref_descriptor(1, index_dtype.to_ctype())),
-                ("index", rt.make_nd_memref_descriptor(2, index_dtype.to_ctype())),
-                ("values", rt.make_nd_memref_descriptor(1, values_dtype.to_ctype())),
-                ("pos_len", np.ctypeslib.c_intp),
-                ("index_len", np.ctypeslib.c_intp),
-                ("values_len", np.ctypeslib.c_intp),
+        def to_module_arg(self) -> list:
+            return [
+                ctypes.pointer(ctypes.pointer(self.pos)),
+                ctypes.pointer(ctypes.pointer(self.coords)),
+                ctypes.pointer(ctypes.pointer(self.data)),
             ]
 
-            def to_sps(self) -> sps.coo_array:
-                pos = rt.ranked_memref_to_numpy([self.pos])[: self.pos_len]
-                index = rt.ranked_memref_to_numpy([self.index])[pos[0] : pos[1]]
-                values = rt.ranked_memref_to_numpy([self.values])[: self.values_len]
-                return sps.coo_array((values, index.T), shape=shape)
-
-        arr = Coo()
-        module.invoke(
-            "disassemble",
-            ctypes.pointer(ctypes.pointer(arr)),
-            ctypes.pointer(ptr),
-        )
-        return arr.to_sps()
-
-
-class CSRFormat(BaseFormat):
-    @classmethod
-    def get_format_str(cls) -> str:
-        return "csr_format"
-
-    @classmethod
-    def get_levels(cls) -> tuple[sparse_tensor.LevelFormat, ...]:
-        return (sparse_tensor.LevelFormat.dense, sparse_tensor.LevelFormat.compressed)
-
-    @classmethod
-    def get_ordering(cls) -> ir.AffineMap:
-        return ir.AffineMap.get_permutation([0, 1])
-
-    @classmethod
-    def get_assemble_functions(
-        cls,
-        module: ir.Module,
-        tensor_shaped: ir.RankedTensorType,
-        values_dtype: type[DType],
-        index_dtype: type[DType],
-    ) -> tuple[typing.Callable, ...]:
-        tensor_1d_index = tensor.RankedTensorType.get([ir.ShapedType.get_dynamic_size()], index_dtype)
-        tensor_1d_values = tensor.RankedTensorType.get([ir.ShapedType.get_dynamic_size()], values_dtype)
-        with ir.InsertionPoint(module.body):
-
-            @func.FuncOp.from_py_func(tensor_1d_index, tensor_1d_index, tensor_1d_values)
-            def assemble(pos, crd, data):
-                return sparse_tensor.assemble(tensor_shaped, (pos, crd), data)
-
-            @func.FuncOp.from_py_func(tensor_shaped)
-            def disassemble(tensor_shaped):
-                pos = tensor.EmptyOp([arith.constant(ir.IndexType.get(), 0)], index_dtype)
-                crd = tensor.EmptyOp([arith.constant(ir.IndexType.get(), 0)], index_dtype)
-                data = tensor.EmptyOp([arith.constant(ir.IndexType.get(), 0)], values_dtype)
-                pos, crd, data, pos_len, crd_len, data_len = sparse_tensor.disassemble(
-                    (tensor_1d_index, tensor_1d_index),
-                    tensor_1d_values,
-                    (index_dtype, index_dtype),
-                    index_dtype,
-                    tensor_shaped,
-                    (pos, crd),
-                    data,
+        @classmethod
+        @fn_cache
+        def get_tensor_definition(cls, shape: tuple[int, ...]) -> ir.RankedTensorType:
+            with ir.Location.unknown(ctx):
+                values_dtype = cls.dtype.get_mlir_type()
+                index_dtype = cls._index_dtype.get_mlir_type()
+                index_width = getattr(index_dtype, "width", 0)
+                compressed_lvl = sparse_tensor.EncodingAttr.build_level_type(
+                    sparse_tensor.LevelFormat.compressed, [sparse_tensor.LevelProperty.non_unique]
                 )
-                return pos, crd, data, pos_len, crd_len, data_len
+                levels = (compressed_lvl, sparse_tensor.LevelFormat.singleton)
+                ordering = ir.AffineMap.get_permutation([0, 1])
+                encoding = sparse_tensor.EncodingAttr.get(levels, ordering, ordering, index_width, index_width)
+                return ir.RankedTensorType.get(list(shape), values_dtype, encoding)
 
-            @func.FuncOp.from_py_func(tensor_shaped)
-            def free_tensor(tensor_shaped):
-                bufferization.dealloc_tensor(tensor_shaped)
+    return Coo
 
-        return assemble, disassemble, free_tensor
 
-    @classmethod
-    def assemble(cls, module: ir.Module, arr: sps.csr_array) -> ctypes.c_void_p:
-        out = ctypes.c_void_p()
-        module.invoke(
-            "assemble",
-            ctypes.pointer(ctypes.pointer(rt.get_ranked_memref_descriptor(arr.indptr))),
-            ctypes.pointer(ctypes.pointer(rt.get_ranked_memref_descriptor(arr.indices))),
-            ctypes.pointer(ctypes.pointer(rt.get_ranked_memref_descriptor(arr.data))),
-            ctypes.pointer(out),
-        )
-        return out
+@fn_cache
+def get_csf_class(values_dtype: type[DType], index_dtype: type[DType]) -> type:
+    raise NotImplementedError
 
-    @classmethod
-    def disassemble(
-        cls,
-        module: ir.Module,
-        ptr: ctypes.c_void_p,
-        shape: list[int],
-        values_dtype: type[DType],
-        index_dtype: type[DType],
-    ) -> sps.csr_array:
-        class Csr(ctypes.Structure):
-            _fields_ = [
-                ("pos", rt.make_nd_memref_descriptor(1, index_dtype.to_ctype())),
-                ("crd", rt.make_nd_memref_descriptor(1, index_dtype.to_ctype())),
-                ("data", rt.make_nd_memref_descriptor(1, values_dtype.to_ctype())),
-                ("pos_len", np.ctypeslib.c_intp),
-                ("crd_len", np.ctypeslib.c_intp),
-                ("data_len", np.ctypeslib.c_intp),
-            ]
 
-            def to_sps(self) -> sps.csr_array:
-                pos = rt.ranked_memref_to_numpy([self.pos])[: self.pos_len]
-                crd = rt.ranked_memref_to_numpy([self.crd])[: self.crd_len]
-                data = rt.ranked_memref_to_numpy([self.data])[: self.data_len]
-                return sps.csr_array((data, crd, pos), shape=shape)
+@fn_cache
+def get_dense_class(values_dtype: type[DType], rank: int) -> type:
+    class Dense(ctypes.Structure):
+        _fields_ = [
+            ("data", get_nd_memref_descr(rank, values_dtype)),
+        ]
+        dtype = values_dtype
 
-        arr = Csr()
-        module.invoke(
-            "disassemble",
-            ctypes.pointer(ctypes.pointer(arr)),
-            ctypes.pointer(ptr),
-        )
-        return arr.to_sps()
+        @classmethod
+        def from_sps(cls, arr: np.ndarray) -> "Dense":
+            data = numpy_to_ranked_memref(arr)
+            return cls(data=data)
+
+        def to_sps(self, shape: tuple[int, ...]) -> sps.csr_array:
+            return ranked_memref_to_numpy(self.data)
+
+        def to_module_arg(self) -> list:
+            return [ctypes.pointer(ctypes.pointer(self.data))]
+
+        @classmethod
+        @fn_cache
+        def get_tensor_definition(cls, shape: tuple[int, ...]) -> ir.RankedTensorType:
+            with ir.Location.unknown(ctx):
+                values_dtype = cls.dtype.get_mlir_type()
+                return ir.RankedTensorType.get(list(shape), values_dtype)
+
+    return Dense
 
 
 def _is_scipy_sparse_obj(x) -> bool:
@@ -468,35 +204,50 @@ def _is_numpy_obj(x) -> bool:
     return isinstance(x, np.ndarray)
 
 
+def _is_mlir_obj(x) -> bool:
+    return isinstance(x, ctypes.Structure)
+
+
+################
+# Tensor class #
+################
+
+
+class Tensor:
+    def __init__(self, obj, shape=None) -> None:
+        self.shape = shape if shape is not None else obj.shape
+        self.values_dtype = asdtype(obj.dtype)
+
+        if _is_scipy_sparse_obj(obj):
+            self.owns_memory = True
+
+            if obj.format == "csr":
+                index_dtype = asdtype(obj.indptr.dtype)
+                self.format_class = get_csr_class(self.values_dtype, index_dtype)
+                self.obj = self.format_class.from_sps(obj)
+            elif obj.format == "coo":
+                index_dtype = asdtype(obj.coords[0].dtype)
+                self.format_class = get_coo_class(self.values_dtype, index_dtype)
+                self.obj = self.format_class.from_sps(obj)
+            else:
+                raise Exception(f"{obj.format} SciPy format not supported.")
+
+        elif _is_numpy_obj(obj):
+            self.owns_memory = True
+            self.format_class = get_dense_class(self.values_dtype, obj.ndim)
+            self.obj = self.format_class.from_sps(obj)
+
+        elif _is_mlir_obj(obj):
+            self.owns_memory = False
+            self.format_class = type(obj)
+            self.obj = obj
+
+        else:
+            raise Exception(f"{type(obj)} not supported.")
+
+    def to_scipy_sparse(self) -> sps.sparray | np.ndarray:
+        return self.obj.to_sps(self.shape)
+
+
 def asarray(obj) -> Tensor:
-    # TODO: discover obj's dtype
-    values_dtype = asdtype(obj.dtype)
-
-    # TODO: support other scipy formats
-    if _is_scipy_sparse_obj(obj):
-        if obj.format == "csr":
-            format_class = CSRFormat
-            index_dtype = asdtype(obj.indptr.dtype)
-        elif obj.format == "coo":
-            format_class = COOFormat
-            index_dtype = asdtype(obj.coords[0].dtype)
-        else:
-            raise Exception(f"{obj.format} SciPy format not supported.")
-    elif _is_numpy_obj(obj):
-        if obj.ndim == 1:
-            format_class = VectorFormat
-        elif obj.ndim == 2:
-            format_class = Dense2DFormat
-        elif obj.ndim == 3:
-            format_class = Dense3DFormat
-        else:
-            raise Exception(f"Rank {obj.ndim} of dense tensor not supported.")
-        index_dtype = Index
-    else:
-        raise Exception(f"{type(obj)} not supported.")
-
-    # TODO: support proper caching
-    module, tensor_type = format_class.get_module(obj.shape, values_dtype, index_dtype)
-
-    assembled_obj = format_class.assemble(module, obj)
-    return Tensor(assembled_obj, module, tensor_type, format_class.disassemble, values_dtype, index_dtype)
+    return Tensor(obj)

--- a/sparse/mlir_backend/_core.py
+++ b/sparse/mlir_backend/_core.py
@@ -17,4 +17,7 @@ libc.free.restype = None
 # TODO: remove global state
 ctx = Context()
 
-pm = PassManager.parse("builtin.module(sparsifier{create-sparse-deallocs=1})", context=ctx)
+pm = PassManager.parse(
+    "builtin.module(sparse-assembler{direct-out=true}, sparsifier{create-sparse-deallocs=1})",
+    context=ctx,
+)

--- a/sparse/mlir_backend/_core.py
+++ b/sparse/mlir_backend/_core.py
@@ -18,6 +18,11 @@ libc.free.restype = None
 ctx = Context()
 
 pm = PassManager.parse(
-    "builtin.module(sparse-assembler{direct-out=true}, sparsifier{create-sparse-deallocs=1})",
+    """
+    builtin.module(
+        sparse-assembler{direct-out=true},
+        sparsifier{create-sparse-deallocs=1 enable-runtime-library=false}
+    )
+    """,
     context=ctx,
 )

--- a/sparse/mlir_backend/_ops.py
+++ b/sparse/mlir_backend/_ops.py
@@ -68,21 +68,21 @@ def get_add_module(
 
 
 def add(x1: Tensor, x2: Tensor) -> Tensor:
-    ret_obj = x1.format_class()
-    out_tensor_type = x1.obj.get_tensor_definition(x1.shape)
+    ret_obj = x1._format_class()
+    out_tensor_type = x1._obj.get_tensor_definition(x1.shape)
 
     # TODO: Add proper caching
     # TODO: Decide what will be the output tensor_type
     add_module = get_add_module(
-        x1.obj.get_tensor_definition(x1.shape),
-        x2.obj.get_tensor_definition(x2.shape),
+        x1._obj.get_tensor_definition(x1.shape),
+        x2._obj.get_tensor_definition(x2.shape),
         out_tensor_type=out_tensor_type,
-        dtype=x1.values_dtype,
+        dtype=x1._values_dtype,
     )
     add_module.invoke(
         "add",
         ctypes.pointer(ctypes.pointer(ret_obj)),
-        *x1.obj.to_module_arg(),
-        *x2.obj.to_module_arg(),
+        *x1._obj.to_module_arg(),
+        *x2._obj.to_module_arg(),
     )
     return Tensor(ret_obj, shape=out_tensor_type.shape)

--- a/sparse/mlir_backend/tests/test_simple.py
+++ b/sparse/mlir_backend/tests/test_simple.py
@@ -89,6 +89,7 @@ def test_constructors(rng, dtype):
     a = sps.random_array(SHAPE, density=DENSITY, format="csr", dtype=dtype, random_state=rng, data_sampler=sampler)
     c = np.arange(math.prod(SHAPE), dtype=dtype).reshape(SHAPE)
     d = sps.random_array(SHAPE, density=DENSITY, format="coo", dtype=dtype, random_state=rng, data_sampler=sampler)
+    d.sum_duplicates()
 
     a_tensor = sparse.asarray(a)
     c_tensor = sparse.asarray(c)
@@ -131,9 +132,15 @@ def test_add(rng, dtype):
     assert isinstance(actual, np.ndarray)
     np.testing.assert_array_equal(actual, expected)
 
-    # TODO: Blocked by https://github.com/llvm/llvm-project/issues/107477
-    # d = sps.random_array(SHAPE, density=DENSITY, format="coo", dtype=dtype, random_state=rng)
-    # d_tensor = sparse.asarray(d)
-    # actual = sparse.add(b_tensor, d_tensor).to_scipy_sparse()
-    # expected = b + d
-    # np.testing.assert_array_equal(actual.todense(), expected.todense())
+    # TODO: Blocked by https://discourse.llvm.org/t/how-to-call-mlir-sparse-module-with-only-dense-inputs-with-python-bindings
+    # actual = sparse.add(c_tensor, c_tensor).to_scipy_sparse()
+    # expected = c + c
+    # assert isinstance(actual, np.ndarray)
+    # np.testing.assert_array_equal(actual, expected)
+
+    d = sps.random_array(SHAPE, density=DENSITY, format="coo", dtype=dtype, random_state=rng)
+    d.sum_duplicates()
+    d_tensor = sparse.asarray(d)
+    actual = sparse.add(b_tensor, d_tensor).to_scipy_sparse()
+    expected = b + d
+    np.testing.assert_array_equal(actual.todense(), expected.todense())

--- a/sparse/mlir_backend/tests/test_simple.py
+++ b/sparse/mlir_backend/tests/test_simple.py
@@ -73,7 +73,7 @@ def generate_sampler(dtype: np.dtype, rng: np.random.Generator) -> typing.Callab
 
 
 @parametrize_dtypes
-@pytest.mark.parametrize("shape", [(100,), (10, 20), (5, 10, 20)])
+@pytest.mark.parametrize("shape", [(100,), (10, 200), (5, 10, 20)])
 def test_dense_format(dtype, shape):
     data = np.arange(math.prod(shape), dtype=dtype)
     tensor = sparse.asarray(data)
@@ -83,8 +83,8 @@ def test_dense_format(dtype, shape):
 
 @parametrize_dtypes
 def test_constructors(rng, dtype):
-    SHAPE = (10, 5)
-    DENSITY = 0.5
+    SHAPE = (80, 100)
+    DENSITY = 0.6
     sampler = generate_sampler(dtype, rng)
     a = sps.random_array(SHAPE, density=DENSITY, format="csr", dtype=dtype, random_state=rng, data_sampler=sampler)
     c = np.arange(math.prod(SHAPE), dtype=dtype).reshape(SHAPE)
@@ -106,13 +106,13 @@ def test_constructors(rng, dtype):
 
 @parametrize_dtypes
 def test_add(rng, dtype):
-    SHAPE = (10, 5)
+    SHAPE = (100, 50)
     DENSITY = 0.5
     sampler = generate_sampler(dtype, rng)
 
     a = sps.random_array(SHAPE, density=DENSITY, format="csr", dtype=dtype, random_state=rng, data_sampler=sampler)
     b = sps.random_array(SHAPE, density=DENSITY, format="csr", dtype=dtype, random_state=rng, data_sampler=sampler)
-    c = np.arange(50, dtype=dtype).reshape((10, 5))
+    c = np.arange(math.prod(SHAPE), dtype=dtype).reshape(SHAPE)
 
     a_tensor = sparse.asarray(a)
     b_tensor = sparse.asarray(b)


### PR DESCRIPTION
Hi @hameerabbasi,

This PR moves MLIR constructors to the direct style (with: `sparse-assembler{direct-out=true}`).
I think it's more concise with this approach - `_constructors.py` LOC reduced by 50%, to 250.

Now all Tensors created from NumPy arrays or SciPy sparse arrays are owned and freed by the python side. 

The ones that are results of MLIR ops (like `add` right now) are allocated by MLIR and `owns_memory` in Tensor class is set to `False`. 

I haven't figured out yet how to correctly free MLIR allocated memrefs, (tried with `libc.free`) as I think there's still a memory leak after `sparse.add(tensor_a, tensor_b)`. 