### PR TITLE
ENH: Add counting triangles example

### DIFF
--- a/examples/triangles_example.py
+++ b/examples/triangles_example.py
@@ -1,0 +1,53 @@
+import importlib
+import os
+
+import sparse
+
+import networkx as nx
+from utils import benchmark
+
+import numpy as np
+
+ITERS = 3
+
+
+if __name__ == "__main__":
+    print("Counting Triangles Example:\n")
+
+    G = nx.gnp_random_graph(n=200, p=0.2)
+
+    # ======= Finch =======
+    os.environ[sparse._ENV_VAR_NAME] = "Finch"
+    importlib.reload(sparse)
+
+    a_sps = nx.to_scipy_sparse_array(G)
+    a = sparse.asarray(a_sps)
+
+    # @sparse.compiled NOTE: blocked by https://github.com/willow-ahrens/Finch.jl/issues/615
+    def count_triangles_finch(a):
+        return sparse.sum(a @ a * a) / 6
+
+    # Compile & Benchmark
+    result_finch = benchmark(count_triangles_finch, args=[a], info="Finch", iters=ITERS)
+
+    # ======= SciPy =======
+    def count_triangles_scipy(a):
+        return (a @ a * a).sum() / 6
+
+    a = nx.to_scipy_sparse_array(G)
+
+    # Compile & Benchmark
+    result_scipy = benchmark(count_triangles_scipy, args=[a], info="SciPy", iters=ITERS)
+
+    # ======= NetworkX =======
+    def count_triangles_networkx(a):
+        return sum(nx.triangles(a).values()) / 3
+
+    a = G
+
+    # Compile & Benchmark
+    result_networkx = benchmark(count_triangles_networkx, args=[a], info="NetworkX", iters=ITERS)
+
+    np.testing.assert_equal(result_finch.todense(), result_scipy)
+    np.testing.assert_equal(result_finch.todense(), result_networkx)
+    assert result_networkx == result_scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ extras = [
     "sparse[finch]",
     "scipy",
     "scikit-learn",
+    "networkx",
 ]
 tests = [
     "sparse[extras]",


### PR DESCRIPTION
Hi @hameerabbasi,

Here's a short example that runs counting triangles with Finch, SciPy, and NetworkX. Two comments:
- The Finch implementation is the slowest right now, it's only run in eager mode as lazy mode is blocked by https://github.com/willow-ahrens/Finch.jl/issues/615
- I see that examples in `examples/` directory aren't executed in the CI job anymore, is it intended? I think they should still be executed.
