### PR TITLE
ENH: Update MLIR backend to LLVM 20.dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,10 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: mamba-org/setup-micromamba@v1.9.0
         with:
+          # NOTE: https://github.com/mamba-org/setup-micromamba/issues/227
+          micromamba-version: '1.5.10-0'
           environment-file: ci/environment.yml
           init-shell: >-
             bash

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - mlir-python-bindings==19.*
   - pip:
-    - finch-tensor >=0.1.31
+    - finch-tensor>=0.1.31
+    - finch-mlir>=0.0.2
     - pytest-codspeed

--- a/sparse/mlir_backend/__init__.py
+++ b/sparse/mlir_backend/__init__.py
@@ -1,7 +1,7 @@
 try:
-    import mlir  # noqa: F401
+    import mlir_finch  # noqa: F401
 
-    del mlir
+    del mlir_finch
 except ModuleNotFoundError as e:
     raise ImportError(
         "MLIR Python bindings not installed. Run "

--- a/sparse/mlir_backend/_common.py
+++ b/sparse/mlir_backend/_common.py
@@ -2,7 +2,7 @@ import ctypes
 import functools
 import weakref
 
-import mlir.runtime as rt
+import mlir_finch.runtime as rt
 
 import numpy as np
 

--- a/sparse/mlir_backend/_core.py
+++ b/sparse/mlir_backend/_core.py
@@ -2,14 +2,28 @@ import ctypes
 import ctypes.util
 import os
 import pathlib
+import sys
 
-from mlir.ir import Context
-from mlir.passmanager import PassManager
+from mlir_finch.ir import Context
+from mlir_finch.passmanager import PassManager
 
 DEBUG = bool(int(os.environ.get("DEBUG", "0")))
 CWD = pathlib.Path(".")
 
+finch_lib_path = f"{sys.prefix}/lib/python3.{sys.version_info.minor}/site-packages/lib"
+
+ld_library_path = os.environ.get("LD_LIBRARY_PATH")
+ld_library_path = f"{finch_lib_path}:{ld_library_path}" if ld_library_path is None else finch_lib_path
+os.environ["LD_LIBRARY_PATH"] = ld_library_path
+
 MLIR_C_RUNNER_UTILS = ctypes.util.find_library("mlir_c_runner_utils")
+if os.name == "posix" and MLIR_C_RUNNER_UTILS is not None:
+    MLIR_C_RUNNER_UTILS = f"{finch_lib_path}/{MLIR_C_RUNNER_UTILS}"
+
+SHARED_LIBS = []
+if MLIR_C_RUNNER_UTILS is not None:
+    SHARED_LIBS.append(MLIR_C_RUNNER_UTILS)
+
 libc = ctypes.CDLL(ctypes.util.find_library("c")) if os.name != "nt" else ctypes.cdll.msvcrt
 libc.free.argtypes = [ctypes.c_void_p]
 libc.free.restype = None

--- a/sparse/mlir_backend/_dtypes.py
+++ b/sparse/mlir_backend/_dtypes.py
@@ -3,8 +3,8 @@ import dataclasses
 import math
 import sys
 
-import mlir.runtime as rt
-from mlir import ir
+import mlir_finch.runtime as rt
+from mlir_finch import ir
 
 import numpy as np
 


### PR DESCRIPTION
This PR replaces https://github.com/pydata/sparse/pull/787 and fixes https://github.com/pydata/sparse/issues/797

---

This PR updates MLIR backend to current LLVM 20.dev (so `main` branch):

- I ran it locally against latest LLVM version.
- Moved COO format to SoA convention [link](https://discourse.llvm.org/t/passmanager-fails-on-simple-coo-addition-example/81247/2?u=mtsokol).
- Updated `tensor.empty` call [link](https://github.com/llvm/llvm-project/pull/110656).

As one can see it fixes a bunch of skips in the test suite: [sparse/mlir_backend/tests/test_simple.py](https://github.com/pydata/sparse/compare/llvm-nightly-test?expand=1#diff-69c60a2345c3e317169e806992fbea9202647744064406623584ea8e96cad54c)

- Dense+Dense and COO+COO now works.
- Reshaping Dense and COO formats also works.

It's thanks to changes already present in `main` branch, added after `19.x` branched, and:
- https://github.com/llvm/llvm-project/pull/108615
- https://github.com/llvm/llvm-project/pull/109135
- https://github.com/llvm/llvm-project/pull/110656
- https://github.com/llvm/llvm-project/pull/110882
