### PR TITLE
Attempt to fix Heisenbug by skipping COO.

### DIFF
--- a/sparse/mlir_backend/tests/test_simple.py
+++ b/sparse/mlir_backend/tests/test_simple.py
@@ -289,6 +289,7 @@ def test_csf_format(dtype):
 
 
 @parametrize_dtypes
+@pytest.mark.skip(reason="https://github.com/llvm/llvm-project/issues/116012")
 def test_coo_3d_format(dtype):
     format = sparse.levels.get_storage_format(
         levels=(


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/pydata/sparse/blob/main/docs/contributing.md

Your PR title should start with any of these abbreviatons: `build`, `chore`, `ci`, `depr`, `docs`, `feat`, `fix`, `perf`, `refactor`, `release`, `test`. Add a `!`at the end, if it is a breaking change.
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] 🪄 Feature
- [x] 🐞 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📚 Documentation
- [ ] 🧪 Test
- [ ] 🛠️ Other

## Related issues

- Related issue #
- Closes #

## Checklist

- [x] Code follows style guide
- [x] Tests added
- [ ] Documented the changes

***

## Please explain your changes below.
This PR fixes a Heisenbug introduced by the 3D COO test, which often caused the `sparse_vector` test (which is the next test to be executed) to fail.

The reason for this was that the COO test was sometimes writing to memory it shouldn't be, IMO. Just another case of COO being broken.
