### PR TITLE
Allow no-copy construction from SciPy COO arrays.

### DIFF
--- a/sparse/mlir_backend/_conversions.py
+++ b/sparse/mlir_backend/_conversions.py
@@ -102,7 +102,7 @@ def _from_scipy(arr: ScipySparseArray, copy: bool | None = None) -> Array:
             )
 
             ret = from_constituent_arrays(format=coo_format, arrays=(pos, row, col, data), shape=arr.shape)
-            if copy is not None and not copy:
+            if not copy:
                 _hold_ref(ret, arr)
             return ret
         case _:

--- a/sparse/mlir_backend/_dtypes.py
+++ b/sparse/mlir_backend/_dtypes.py
@@ -33,6 +33,11 @@ class DType(MlirType):
     def to_ctype(self):
         return rt.as_ctype(self.np_dtype)
 
+    def __eq__(self, value):
+        if np.isdtype(value) or isinstance(value, str):
+            value = asdtype(value)
+        return super().__eq__(value)
+
 
 @dataclasses.dataclass(eq=True, frozen=True, kw_only=True)
 class IeeeRealFloatingDType(DType):

--- a/sparse/mlir_backend/tests/test_simple.py
+++ b/sparse/mlir_backend/tests/test_simple.py
@@ -465,8 +465,7 @@ def test_asformat(rng, src_fmt, dst_fmt):
 
     expected = sps_arr.asformat(dst_fmt)
 
-    copy = None if dst_fmt == "coo" else False
-    actual_fmt = sparse.asarray(expected, copy=copy).format
+    actual_fmt = sparse.asarray(expected, copy=False).format
     actual = sp_arr.asformat(actual_fmt)
     actual_sps = sparse.to_scipy(actual)
 

--- a/sparse/mlir_backend/tests/test_simple.py
+++ b/sparse/mlir_backend/tests/test_simple.py
@@ -301,7 +301,7 @@ def test_coo_3d_format(dtype):
 @parametrize_dtypes
 def test_sparse_vector_format(dtype):
     if sparse.asdtype(dtype) in {sparse.complex64, sparse.complex128}:
-        pytest.xfail("Heisenbug")
+        pytest.xfail("The sparse_vector format returns incorrect results for complex dtypes.")
     format = sparse.formats.Coo().with_ndim(1).with_dtype(dtype).build()
 
     SHAPE = (10,)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/pydata/sparse/blob/main/docs/contributing.md

Your PR title should start with any of these abbreviatons: `build`, `chore`, `ci`, `depr`, `docs`, `feat`, `fix`, `perf`, `refactor`, `release`, `test`. Add a `!`at the end, if it is a breaking change.
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] 🪄 Feature
- [x] 🐞 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📚 Documentation
- [ ] 🧪 Test
- [ ] 🛠️ Other

## Related issues

- Related issue #
- Closes #

## Checklist

- [ ] Code follows style guide
- [ ] Tests added
- [ ] Documented the changes

***

## Please explain your changes below.
- Hold reference to converted scipy.sparse.coo_*.
- Allow comparison against NumPy dtypes.
- Add a sentence explaining the sparse_vector failure.