### PR TITLE
Remove workaround introduced in #822.

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -48,7 +48,7 @@ matrepr = "*"
 precompile = "python -c 'import finch'"
 
 [feature.finch.pypi-dependencies]
-scipy = ">=0.19"
+scipy = ">=1.13"
 finch-tensor = ">=0.2.1"
 
 [feature.finch.activation.env]

--- a/sparse/mlir_backend/_conversions.py
+++ b/sparse/mlir_backend/_conversions.py
@@ -78,8 +78,6 @@ def _from_scipy(arr: ScipySparseArray, copy: bool | None = None) -> Array:
 
             return from_constituent_arrays(format=csx_format, arrays=(indptr, indices, data), shape=arr.shape)
         case "coo":
-            from ._common import _hold_ref
-
             row, col = arr.row, arr.col
             if row.dtype != col.dtype:
                 raise RuntimeError(f"`row` and `col` dtypes must be the same: {row.dtype} != {col.dtype}.")
@@ -101,10 +99,7 @@ def _from_scipy(arr: ScipySparseArray, copy: bool | None = None) -> Array:
                 .build()
             )
 
-            ret = from_constituent_arrays(format=coo_format, arrays=(pos, row, col, data), shape=arr.shape)
-            if not copy:
-                _hold_ref(ret, arr)
-            return ret
+            return from_constituent_arrays(format=coo_format, arrays=(pos, row, col, data), shape=arr.shape)
         case _:
             raise NotImplementedError(f"No conversion implemented for `scipy.sparse.{type(arr.__name__)}`.")
 


### PR DESCRIPTION
I tested the latest bugfix releases for SciPy from 1.12 to 1.14; and none of them have this issue. I think it's safe to remove the workaround.