### PR TITLE
feat: Greek letters in einsum

### DIFF
--- a/sparse/numba_backend/_common.py
+++ b/sparse/numba_backend/_common.py
@@ -19,7 +19,7 @@ from ._utils import (
     normalize_axis,
 )
 
-_EINSUM_SYMBOLS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+_EINSUM_SYMBOLS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZαβγδϵζηθικλμνξπρστυϕχψωΓΔΕΘΛΠΡΣΦΨΩ"
 _EINSUM_SYMBOLS_SET = set(_EINSUM_SYMBOLS)
 
 

--- a/sparse/numba_backend/tests/test_einsum.py
+++ b/sparse/numba_backend/tests/test_einsum.py
@@ -82,7 +82,7 @@ einsum_cases = [
 ]
 
 
-@pytest.mark.parametrize("symbols", sparse.numba_backend._common._EINSUM_SYMBOLS_SET)
+@pytest.mark.parametrize("symbols", sparse.numba_backend._common._EINSUM_SYMBOLS)
 def test_symbols(symbols):
     arr = sparse.random(shape=10, density=1.0)
 

--- a/sparse/numba_backend/tests/test_einsum.py
+++ b/sparse/numba_backend/tests/test_einsum.py
@@ -84,7 +84,6 @@ einsum_cases = [
 
 @pytest.mark.parametrize("symbols", sparse.numba_backend._common._EINSUM_SYMBOLS_SET)
 def test_symbols(symbols):
-
     arr = sparse.random(shape=10, density=1.0)
 
     # ensure we can use any of the defined symbols

--- a/sparse/numba_backend/tests/test_einsum.py
+++ b/sparse/numba_backend/tests/test_einsum.py
@@ -82,6 +82,16 @@ einsum_cases = [
 ]
 
 
+@pytest.mark.parametrize("symbols", sparse.numba_backend._common._EINSUM_SYMBOLS_SET)
+def test_symbols(symbols):
+
+    arr = sparse.random(shape=10, density=1.0)
+
+    # ensure we can use any of the defined symbols
+    for symbol in symbols:
+        sparse.einsum(f"{symbol}->{symbol}", arr)
+
+
 @pytest.mark.parametrize("subscripts", einsum_cases)
 @pytest.mark.parametrize("density", [0.1, 1.0])
 def test_einsum(subscripts, density):


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/pydata/sparse/blob/main/docs/contributing.md

Your PR title should start with any of these abbreviatons: `build`, `chore`, `ci`, `depr`, `docs`, `feat`, `fix`, `perf`, `refactor`, `release`, `test`. Add a `!`at the end, if it is a breaking change.
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [X] 🪄 Feature
- [ ] 🐞 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📚 Documentation
- [ ] 🧪 Test
- [ ] 🛠️ Other

## Related issues

- Related issue #
- Closes #

## Checklist

- [ ] Code follows style guide
- [X] Tests added
- [ ] Documented the changes

***

## Please explain your changes below.

Added Greek letters to valid einsum symbols, and a test that ensures all einsum symbols get parsed properly.

Just a QOL change, makes it easier to translate some tensor contractions that might use Greek letters by convention