### PR TITLE
Fix CSC/CSR `.mT` fill-value result

### DIFF
--- a/ci/Finch-array-api-xfails.txt
+++ b/ci/Finch-array-api-xfails.txt
@@ -162,7 +162,6 @@ array_api_tests/test_has_names.py::test_has_names[array_method-__dlpack__]
 array_api_tests/test_has_names.py::test_has_names[array_method-__dlpack_device__]
 array_api_tests/test_has_names.py::test_has_names[array_method-__setitem__]
 array_api_tests/test_has_names.py::test_has_names[array_attribute-T]
-array_api_tests/test_has_names.py::test_has_names[array_attribute-mT]
 
 # test_indexing_functions
 

--- a/sparse/numba_backend/_compressed/compressed.py
+++ b/sparse/numba_backend/_compressed/compressed.py
@@ -913,7 +913,7 @@ class CSR(_Compressed2d):
             self = self.copy()
         if axes == (0, 1):
             return self
-        return CSC((self.data, self.indices, self.indptr), self.shape[::-1])
+        return CSC((self.data, self.indices, self.indptr), self.shape[::-1], fill_value=self.fill_value)
 
 
 class CSC(_Compressed2d):
@@ -945,4 +945,4 @@ class CSC(_Compressed2d):
             self = self.copy()
         if axes == (0, 1):
             return self
-        return CSR((self.data, self.indices, self.indptr), self.shape[::-1])
+        return CSR((self.data, self.indices, self.indptr), self.shape[::-1], fill_value=self.fill_value)

--- a/sparse/numba_backend/tests/test_compressed_2d.py
+++ b/sparse/numba_backend/tests/test_compressed_2d.py
@@ -117,6 +117,13 @@ def test_transpose(random_sparse, copy):
         random_sparse.transpose(axes=0)
 
 
+@pytest.mark.parametrize("format", ["csr", "csc"])
+def test_mT_fill_value(format):
+    fv = 1.0
+    arr = sparse.full((10, 20), fill_value=fv, format=format)
+    assert_eq(arr.mT, sparse.full((20, 10), fill_value=fv))
+
+
 def test_transpose_error(random_sparse):
     with pytest.raises(ValueError):
         random_sparse.transpose(axes=1)


### PR DESCRIPTION
Hi @hameerabbasi,

It looks like transposing CSC/CSR drops fill-value. Here's a fix.