### PR TITLE
Make `vecdot` compliant to the Array API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       exclude: ".ipynb"
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.4
+  rev: v0.9.6
   hooks:
     - id: ruff
       args: ["--fix"]

--- a/ci/Numba-array-api-xfails.txt
+++ b/ci/Numba-array-api-xfails.txt
@@ -41,7 +41,6 @@ array_api_tests/test_has_names.py::test_has_names[array_method-__dlpack__]
 array_api_tests/test_has_names.py::test_has_names[array_method-__dlpack_device__]
 array_api_tests/test_has_names.py::test_has_names[array_method-__setitem__]
 array_api_tests/test_indexing_functions.py::test_take
-array_api_tests/test_linalg.py::test_vecdot
 array_api_tests/test_set_functions.py::test_unique_all
 array_api_tests/test_set_functions.py::test_unique_inverse
 array_api_tests/test_signatures.py::test_func_signature[unique_all]

--- a/sparse/numba_backend/_common.py
+++ b/sparse/numba_backend/_common.py
@@ -3102,4 +3102,4 @@ def vecdot(x1, x2, /, *, axis=-1):
     if np.issubdtype(x1.dtype, np.complexfloating):
         x1 = np.conjugate(x1)
 
-    return np.sum(x1 * x2, axis=axis)
+    return np.sum(x1 * x2, axis=axis, dtype=np.result_type(x1, x2))

--- a/sparse/numba_backend/tests/test_coo.py
+++ b/sparse/numba_backend/tests/test_coo.py
@@ -1851,8 +1851,8 @@ def test_vecdot(shape1, shape2, axis, density, rng, is_complex):
         return np.sum(x1 * x2, axis=axis)
 
     actual = sparse.vecdot(s1, s2, axis=axis)
+    assert s1.dtype == s2.dtype == actual.dtype
     expected = np_vecdot(x1, x2, axis=axis)
-
     np.testing.assert_allclose(actual.todense(), expected)
 
 


### PR DESCRIPTION
Trying to fix :
```
test_vecdot - AssertionError: out.dtype=uint64, but should be uint8 [vecdot(uint8, uint8)]
```
while running `array_api_tests`.
