### PR TITLE
Addressing array api failure for sort() function

### DIFF
--- a/ci/Numba-array-api-xfails.txt
+++ b/ci/Numba-array-api-xfails.txt
@@ -55,7 +55,6 @@ array_api_tests/test_signatures.py::test_array_method_signature[__dlpack__]
 array_api_tests/test_signatures.py::test_array_method_signature[__dlpack_device__]
 array_api_tests/test_signatures.py::test_array_method_signature[__setitem__]
 array_api_tests/test_sorting_functions.py::test_argsort
-array_api_tests/test_sorting_functions.py::test_sort
 array_api_tests/test_special_cases.py::test_nan_propagation[max]
 array_api_tests/test_special_cases.py::test_nan_propagation[mean]
 array_api_tests/test_special_cases.py::test_nan_propagation[min]

--- a/sparse/numba_backend/_coo/common.py
+++ b/sparse/numba_backend/_coo/common.py
@@ -1307,8 +1307,12 @@ def sort(x, /, *, axis=-1, descending=False, stable=False):
 
     x = x.reshape(x_shape[:-1] + (x_shape[-1],))
     x = moveaxis(x, source=-1, destination=axis)
-
-    return x if original_ndim == x.ndim else x.squeeze()
+    if original_ndim == x.ndim:
+        return x
+    x = x.squeeze()
+    if x.shape == ():
+        return x[None]
+    return x
 
 
 def take(x, indices, /, *, axis=None):


### PR DESCRIPTION
Removes :

```
FAILED ../array-api-tests/array_api_tests/test_sorting_functions.py::test_sort - AssertionError: out.shape=(), but should be (1,) [sort()]
```
While running array-api-tests.