### PR TITLE
fix: Fix for `check_zero_fill_value` and `equivalent`

### DIFF
--- a/sparse/numba_backend/_utils.py
+++ b/sparse/numba_backend/_utils.py
@@ -440,7 +440,7 @@ def equivalent(x, y, /, loose=False):
 
     if loose:
         if np.issubdtype(dt, np.complexfloating):
-            return equivalent(x.real, y.real) & equivalent(x.imag, y.imag)
+            return equivalent(x.real, y.real, loose=True) & equivalent(x.imag, y.imag, loose=True)
 
         # TODO: Rec array handling
         return (x == y) | ((x != x) & (y != y))
@@ -559,7 +559,7 @@ def check_fill_value(x, /, *, accept_fv=None) -> None:
         raise ValueError(f"{x.fill_value=} but should be in {accept_fv}.")
 
 
-def check_zero_fill_value(*args):
+def check_zero_fill_value(*args, loose=True):
     """
     Checks if all the arguments have zero fill-values.
 
@@ -588,7 +588,7 @@ def check_zero_fill_value(*args):
     ValueError: This operation requires zero fill values, but argument 1 had a fill value of 0.5.
     """
     for i, arg in enumerate(args):
-        if hasattr(arg, "fill_value") and not equivalent(arg.fill_value, _zero_of_dtype(arg.dtype)):
+        if hasattr(arg, "fill_value") and not equivalent(arg.fill_value, _zero_of_dtype(arg.dtype), loose=loose):
             raise ValueError(
                 f"This operation requires zero fill values, but argument {i:d} had a fill value of {arg.fill_value!s}."
             )

--- a/sparse/numba_backend/tests/test_coo.py
+++ b/sparse/numba_backend/tests/test_coo.py
@@ -1919,3 +1919,13 @@ def test_to_invalid_device():
     s = sparse.random((5, 5), density=0.5)
     with pytest.raises(ValueError, match=r"Only .* is supported."):
         s.to_device("invalid_device")
+
+
+# regression test for gh-869
+def test_xH_x():
+    Y = np.array([[0, -1j], [+1j, 0]])
+    Ysp = COO.from_numpy(Y)
+
+    assert_eq(Ysp.conj().T @ Y, Y.conj().T @ Y)
+    assert_eq(Ysp.conj().T @ Ysp, Y.conj().T @ Y)
+    assert_eq(Y.conj().T @ Ysp.conj().T, Y.conj().T @ Y.conj().T)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/pydata/sparse/blob/main/docs/contributing.md

Your PR title should start with any of these abbreviatons: `build`, `chore`, `ci`, `depr`, `docs`, `feat`, `fix`, `perf`, `refactor`, `release`, `test`. Add a `!`at the end, if it is a breaking change.
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] 🪄 Feature
- [x] 🐞 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📚 Documentation
- [ ] 🧪 Test
- [ ] 🛠️ Other

## Related issues

- Closes #869 

## Checklist

- [x] Code follows style guide
- [x] Tests added
- [ ] Documented the changes

***

## Please explain your changes below.
Fixes an issue with complex dtypes and `loose=True`.
Use loose comparisons for `check_zero_fill_value`.
