### PR TITLE
BUG: asarray: fix default format for `SparseArray` input

### DIFF
--- a/sparse/numba_backend/_common.py
+++ b/sparse/numba_backend/_common.py
@@ -2073,7 +2073,7 @@ def format_to_string(format):
 
 
 @_check_device
-def asarray(obj, /, *, dtype=None, format="coo", copy=False, device=None):
+def asarray(obj, /, *, dtype=None, format=None, copy=False, device=None):
     """
     Convert the input to a sparse array.
 
@@ -2085,6 +2085,8 @@ def asarray(obj, /, *, dtype=None, format="coo", copy=False, device=None):
         Output array data type.
     format : str, optional
         Output array sparse format.
+        Default: existing format if the input is a `SparseArray`,
+        else COO.
     device : str, optional
         Device on which to place the created array.
     copy : bool, optional
@@ -2102,7 +2104,7 @@ def asarray(obj, /, *, dtype=None, format="coo", copy=False, device=None):
     <COO: shape=(8, 8), dtype=int64, nnz=8, fill_value=0>
     """
 
-    if format not in {"coo", "dok", "gcxs", "csc", "csr"}:
+    if format not in {None, "coo", "dok", "gcxs", "csc", "csr"}:
         raise ValueError(f"{format} format not supported.")
 
     from ._compressed import CSC, CSR, GCXS
@@ -2111,8 +2113,10 @@ def asarray(obj, /, *, dtype=None, format="coo", copy=False, device=None):
 
     format_dict = {"coo": COO, "dok": DOK, "gcxs": GCXS, "csc": CSC, "csr": CSR}
 
-    if isinstance(obj, COO | DOK | GCXS | CSC | CSR):
-        return obj.asformat(format)
+    if isinstance(obj, SparseArray):
+        return obj.asformat(format) if format is not None else obj
+
+    format = "coo" if format is None else format
 
     if _is_scipy_sparse_obj(obj):
         sparse_obj = format_dict[format].from_scipy_sparse(obj)

--- a/sparse/numba_backend/tests/test_array_function.py
+++ b/sparse/numba_backend/tests/test_array_function.py
@@ -1,4 +1,5 @@
 import sparse
+from sparse.numba_backend import SparseArray
 from sparse.numba_backend._settings import NEP18_ENABLED
 from sparse.numba_backend._utils import assert_eq
 
@@ -132,3 +133,6 @@ class TestAsarray:
         expected = input.todense() if hasattr(input, "todense") else np.asarray(input)
 
         np.testing.assert_equal(actual, expected)
+
+        if isinstance(input, SparseArray):
+            assert sparse.asarray(input).__class__ is input.__class__


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/pydata/sparse/blob/main/docs/contributing.md

Your PR title should start with any of these abbreviatons: `build`, `chore`, `ci`, `depr`, `docs`, `feat`, `fix`, `perf`, `refactor`, `release`, `test`. Add a `!`at the end, if it is a breaking change.
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] 🪄 Feature
- [x] 🐞 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📚 Documentation
- [ ] 🧪 Test
- [ ] 🛠️ Other

## Checklist

- [x] Code follows style guide
- [x] Tests added
- [x] Documented the changes

***

fixes

```
In [16]: sparse.asarray(sparse.GCXS.from_numpy(np.empty(0)))
Out[16]: <COO: shape=(0,), dtype=float64, nnz=0, fill_value=0.0>
```