### PR TITLE
perf: short-circuit COO.reshape when -1 resolves to self.shape

### DIFF
--- a/sparse/numba_backend/_coo/core.py
+++ b/sparse/numba_backend/_coo/core.py
@@ -1070,7 +1070,7 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         if order not in {"C", None}:
             raise NotImplementedError("The `order` parameter is not supported")
 
-        if any(d == -1 for d in shape):
+        if -1 in shape:
             extra = int(self.size / np.prod([d for d in shape if d != -1]))
             shape = tuple([d if d != -1 else extra for d in shape])
         if self.shape == shape:

--- a/sparse/numba_backend/_coo/core.py
+++ b/sparse/numba_backend/_coo/core.py
@@ -1070,11 +1070,11 @@ class COO(SparseArray, NDArrayOperatorsMixin):  # lgtm [py/missing-equals]
         if order not in {"C", None}:
             raise NotImplementedError("The `order` parameter is not supported")
 
-        if self.shape == shape:
-            return self
         if any(d == -1 for d in shape):
             extra = int(self.size / np.prod([d for d in shape if d != -1]))
             shape = tuple([d if d != -1 else extra for d in shape])
+        if self.shape == shape:
+            return self
 
         if self.size != reduce(operator.mul, shape, 1):
             raise ValueError(f"cannot reshape array of size {self.size} into shape {shape}")


### PR DESCRIPTION
## Summary

Two small changes to `COO.reshape`:

1. Resolve any `-1` in the target shape **before** the `self.shape == shape` short-circuit, rather than after.
2. Replace `any(d == -1 for d in shape)` with `-1 in shape` (C-level tuple containment).

```diff
-        if self.shape == shape:
-            return self
-        if any(d == -1 for d in shape):
+        if -1 in shape:
             extra = int(self.size / np.prod([d for d in shape if d != -1]))
             shape = tuple([d if d != -1 else extra for d in shape])
+        if self.shape == shape:
+            return self
```

## Why

`sparse.tensordot` reshapes its operands to 2D with calls like `a.reshape((-1, K))`. When `a` is already 2D with trailing dim `K`, the target shape equals `a.shape` — but the equality check runs **before** `-1` is resolved, so it doesn't match. The full reshape path (`linear_loc()`, coord rebuild, new `COO` allocation) then runs and produces a copy identical to the input.

Resolving `-1` first lets the short-circuit catch this case and return `self`. The `-1 in shape` swap is a readability / micro-perf nit that matters here because unconditionally checking for `-1` before the equality short-circuit (which the first change requires) would otherwise add ~200 ns to every reshape — including the exact-shape case that was already hitting the short-circuit.

## Semantics

Strictly fewer copies:

- Any call that previously returned `self` still does (exact-shape input has no `-1`, so the resolution step is a no-op and the equality check sees the same `shape`).
- `reshape((-1, ...))` that resolves to the current shape now also returns `self`. This is consistent with the documented behavior (`test_reshape_same` codifies `s.reshape(s.shape) is s`) and matches NumPy, which similarly does not promise a copy from `ndarray.reshape` when the target is equivalent.
- Error paths are unchanged — the size-mismatch `ValueError` below still runs with the resolved shape.
- `-1 in shape` is equivalent to `any(d == -1 for d in shape)` because `shape` is already a tuple of ints by this point.

## Minimal repro

Run with the project's `pixi` env (`pixi run -e test python <file>`), or standalone with `uv run --with sparse --with numpy python <file>`:

```python
import time
import numpy as np
import sparse

# Moderately sparse matrix; shape picked so (-1, 300) resolves to self.shape
a = sparse.random((200, 300), density=0.02, random_state=0)
N = 20_000

t0 = time.perf_counter()
for _ in range(N):
    a.reshape((-1, 300))          # the hot tensordot pattern
dt_neg1 = time.perf_counter() - t0

t0 = time.perf_counter()
for _ in range(N):
    a.reshape(a.shape)            # already-short-circuited path for comparison
dt_exact = time.perf_counter() - t0

print(f"reshape((-1, 300)): {dt_neg1*1e6/N:6.1f} us/call")
print(f"reshape(a.shape):   {dt_exact*1e6/N:6.1f} us/call")

# Correctness: -1 resolution returning self is consistent with exact-shape
assert a.reshape((-1, 300)) is a
assert a.reshape(a.shape) is a
```

Measured on this script (macOS / Python 3.13, median of 3 runs):

| | `reshape((-1, 300))` | `reshape(a.shape)` |
|---|---:|---:|
| `main` | 22.7 μs/call | 0.2 μs/call |
| this PR | 2.3 μs/call | 0.2 μs/call |

~10× faster on the `(-1, K)` pattern, exact-shape path unchanged. All 6050 existing numba-backend tests pass.