### PR TITLE
fix: treat NaN values as distinct in unique_values and unique_counts

### DIFF
--- a/sparse/numba_backend/_coo/common.py
+++ b/sparse/numba_backend/_coo/common.py
@@ -1211,13 +1211,19 @@ def unique_counts(x, /):
     x = _validate_coo_input(x)
 
     x = x.flatten()
-    values, counts = np.unique(x.data, return_counts=True)
-    if x.nnz < x.size:
-        values = np.concatenate([[x.fill_value], values])
-        counts = np.concatenate([[x.size - x.nnz], counts])
-        sorted_indices = np.argsort(values)
-        values[sorted_indices] = values.copy()
-        counts[sorted_indices] = counts.copy()
+    values, counts = np.unique(x.data, return_counts=True, equal_nan=False)
+    fill_count = x.size - x.nnz
+    if fill_count > 0:
+        if np.isnan(x.fill_value):
+            # Per the Array API spec, NaNs compare as False, so each NaN is distinct.
+            values = np.concatenate([values, np.full(fill_count, np.nan)])
+            counts = np.concatenate([counts, np.ones(fill_count, dtype=counts.dtype)])
+        else:
+            values = np.concatenate([[x.fill_value], values])
+            counts = np.concatenate([[fill_count], counts])
+            sorted_indices = np.argsort(values)
+            values[sorted_indices] = values.copy()
+            counts[sorted_indices] = counts.copy()
 
     return UniqueCountsResult(values, counts)
 
@@ -1252,9 +1258,14 @@ def unique_values(x, /):
     x = _validate_coo_input(x)
 
     x = x.flatten()
-    values = np.unique(x.data)
-    if x.nnz < x.size:
-        values = np.sort(np.concatenate([[x.fill_value], values]))
+    values = np.unique(x.data, equal_nan=False)
+    fill_count = x.size - x.nnz
+    if fill_count > 0:
+        if np.isnan(x.fill_value):
+            # Per the Array API spec, NaNs compare as False, so each NaN is distinct.
+            values = np.concatenate([values, np.full(fill_count, np.nan)])
+        else:
+            values = np.sort(np.concatenate([[x.fill_value], values]))
     return values
 
 

--- a/sparse/numba_backend/_coo/common.py
+++ b/sparse/numba_backend/_coo/common.py
@@ -1216,7 +1216,7 @@ def unique_counts(x, /):
     if fill_count > 0:
         if np.isnan(x.fill_value):
             # Per the Array API spec, NaNs compare as False, so each NaN is distinct.
-            values = np.concatenate([values, np.full(fill_count, np.nan)])
+            values = np.concatenate([values, np.full(fill_count, x.fill_value)])
             counts = np.concatenate([counts, np.ones(fill_count, dtype=counts.dtype)])
         else:
             values = np.concatenate([[x.fill_value], values])
@@ -1263,7 +1263,7 @@ def unique_values(x, /):
     if fill_count > 0:
         if np.isnan(x.fill_value):
             # Per the Array API spec, NaNs compare as False, so each NaN is distinct.
-            values = np.concatenate([values, np.full(fill_count, np.nan)])
+            values = np.concatenate([values, np.full(fill_count, x.fill_value)])
         else:
             values = np.sort(np.concatenate([[x.fill_value], values]))
     return values

--- a/sparse/numba_backend/tests/test_coo.py
+++ b/sparse/numba_backend/tests/test_coo.py
@@ -1743,6 +1743,15 @@ class TestUnique:
         assert all(np.isnan(result.values))
         np.testing.assert_equal(result.counts, [1, 1, 1])
 
+    def test_unique_counts_nan_fill_value(self):
+        # When fill_value is NaN, each un-stored slot is a distinct NaN count.
+        arr = sparse.COO(coords=[[0, 2]], data=[1.0, 2.0], shape=(4,), fill_value=float("nan"))
+        result = sparse.unique_counts(arr)
+        # dense: [1., nan, 2., nan] -> unique counts: [(1., 1), (2., 1), (nan, 1), (nan, 1)]
+        np.testing.assert_equal(result.values[:2], [1.0, 2.0])
+        assert all(np.isnan(result.values[2:]))
+        np.testing.assert_equal(result.counts, [1, 1, 1, 1])
+
     @pytest.mark.parametrize("func", [sparse.unique_counts, sparse.unique_values])
     def test_input_validation(self, func):
         with pytest.raises(ValueError, match="Input must be an instance of SparseArray"):

--- a/sparse/numba_backend/tests/test_coo.py
+++ b/sparse/numba_backend/tests/test_coo.py
@@ -1718,6 +1718,31 @@ class TestUnique:
 
         np.testing.assert_equal(result, expected)
 
+    def test_unique_values_nan_distinct(self):
+        # Per the Array API spec, NaN values compare as False and must be treated
+        # as distinct elements, not collapsed into one.
+        arr = sparse.asarray([float("nan"), float("nan")])
+        result = sparse.unique_values(arr)
+        assert result.shape == (2,)
+        assert all(np.isnan(result))
+
+    def test_unique_values_nan_fill_value(self):
+        # When fill_value is NaN, each un-stored slot is a distinct NaN.
+        arr = sparse.COO(coords=[[0, 2]], data=[1.0, 2.0], shape=(4,), fill_value=float("nan"))
+        result = sparse.unique_values(arr)
+        # dense: [1., nan, 2., nan] -> unique (nan distinct): [1., 2., nan, nan]
+        assert result.shape == (4,)
+        np.testing.assert_equal(result[:2], [1.0, 2.0])
+        assert all(np.isnan(result[2:]))
+
+    def test_unique_counts_nan_distinct(self):
+        # Each NaN occurrence must be counted separately.
+        arr = sparse.asarray([float("nan"), float("nan"), float("nan")])
+        result = sparse.unique_counts(arr)
+        assert result.values.shape == (3,)
+        assert all(np.isnan(result.values))
+        np.testing.assert_equal(result.counts, [1, 1, 1])
+
     @pytest.mark.parametrize("func", [sparse.unique_counts, sparse.unique_values])
     def test_input_validation(self, func):
         with pytest.raises(ValueError, match="Input must be an instance of SparseArray"):


### PR DESCRIPTION
## Summary

Fixes #855.

The [Array API specification](https://data-apis.org/array-api/latest/API_specification/generated/array_api.unique_values.html) states:

> As nan values compare as False, nan values should be considered distinct.

Both `unique_values` and `unique_counts` were using `np.unique` (which defaults to `equal_nan=True`), causing multiple NaN values to be collapsed into a single entry:

```python
>>> import sparse
>>> sparse.unique_values(sparse.asarray([float('nan'), float('nan')]))
array([nan])   # wrong: should be [nan, nan]
```

## Changes

- Pass `equal_nan=False` to `np.unique` so NaN values in stored data are kept distinct.
- Handle the case where `fill_value` is NaN: instead of prepending a single fill-value entry, append one distinct NaN per un-stored slot.

## After fix

```python
>>> sparse.unique_values(sparse.asarray([float('nan'), float('nan')]))
array([nan, nan])   # correct

>>> sparse.unique_counts(sparse.asarray([float('nan'), float('nan'), float('nan')]))
UniqueCountsResult(values=array([nan, nan, nan]), counts=array([1, 1, 1]))   # correct
```

Three new tests covering:
1. NaN values in stored data treated as distinct by `unique_values`
2. NaN fill-value slots each producing a distinct NaN entry
3. NaN values counted individually by `unique_counts`

---

This pull request was prepared with the assistance of AI, under my direction and review.