### PR TITLE
fix: avoid narrow-dtype overflow in reduceat group offsets

### DIFF
--- a/sparse/numba_backend/_coo/core.py
+++ b/sparse/numba_backend/_coo/core.py
@@ -1600,13 +1600,18 @@ def as_coo(x, shape=None, fill_value=None, idx_dtype=None):
 
 @numba.jit(nopython=True, nogil=True)  # pragma: no cover
 def _calc_counts_invidx(groups):
+    # NB: inv_idx/counts index into the (potentially much larger) nnz-length data
+    # array, so they must not be narrowed to groups.dtype, which is only sized to fit
+    # the group values (e.g. a shape dimension). Doing so silently overflows for
+    # arrays with more stored elements than the dtype max, e.g. int16 wraps negative
+    # past 32767 nnz, causing an IndexError in the np.add.reduceat call downstream.
     inv_idx = []
     counts = []
 
     if len(groups) == 0:
         return (
-            np.array(inv_idx, dtype=groups.dtype),
-            np.array(counts, dtype=groups.dtype),
+            np.array(inv_idx, dtype=np.int64),
+            np.array(counts, dtype=np.int64),
         )
 
     inv_idx.append(0)
@@ -1620,7 +1625,7 @@ def _calc_counts_invidx(groups):
 
     counts.append(len(groups) - inv_idx[-1])
 
-    return (np.array(inv_idx, dtype=groups.dtype), np.array(counts, dtype=groups.dtype))
+    return (np.array(inv_idx, dtype=np.int64), np.array(counts, dtype=np.int64))
 
 
 def _grouped_reduce(x, groups, method, **kwargs):

--- a/sparse/numba_backend/_coo/core.py
+++ b/sparse/numba_backend/_coo/core.py
@@ -1610,8 +1610,8 @@ def _calc_counts_invidx(groups):
 
     if len(groups) == 0:
         return (
-            np.array(inv_idx, dtype=np.int64),
-            np.array(counts, dtype=np.int64),
+            np.array(inv_idx, dtype=np.intp),
+            np.array(counts, dtype=np.intp),
         )
 
     inv_idx.append(0)
@@ -1619,13 +1619,13 @@ def _calc_counts_invidx(groups):
     last_group = groups[0]
     for i in range(1, len(groups)):
         if groups[i] != last_group:
-            counts.append(i - inv_idx[-1])
-            inv_idx.append(i)
+            counts.append(np.intp(i - inv_idx[-1]))
+            inv_idx.append(np.intp(i))
             last_group = groups[i]
 
-    counts.append(len(groups) - inv_idx[-1])
+    counts.append(np.intp(len(groups) - inv_idx[-1]))
 
-    return (np.array(inv_idx, dtype=np.int64), np.array(counts, dtype=np.int64))
+    return (np.array(inv_idx, dtype=np.intp), np.array(counts, dtype=np.intp))
 
 
 def _grouped_reduce(x, groups, method, **kwargs):

--- a/sparse/numba_backend/tests/test_coo.py
+++ b/sparse/numba_backend/tests/test_coo.py
@@ -762,6 +762,25 @@ def test_large_sum(rng):
     assert b.nnz > 100000
 
 
+def test_reduce_narrow_idx_dtype(rng):
+    # Regression test: a narrow idx_dtype is a legitimate choice when the array
+    # *shape* is small, but reductions must not reuse that dtype for internal
+    # group offsets, which index into the (possibly much larger) nnz-length data
+    # array. Previously overflowed/wrapped negative once nnz exceeded the dtype's
+    # max (e.g. 32767 for int16), raising "IndexError: index ... out-of-bounds in
+    # add.reduceat".
+    shape = (200, 20, 10)
+    coords = np.mgrid[0 : shape[0], 0 : shape[1], 0 : shape[2]].reshape(3, -1)
+    data = rng.random(coords.shape[1])
+    a = COO(coords, data, shape=shape, idx_dtype=np.int16)
+    assert a.nnz > np.iinfo(np.int16).max
+
+    x = a.todense()
+    assert_eq(a.sum(axis=(1, 2)), x.sum(axis=(1, 2)))
+    assert_eq(a.mean(axis=(1, 2)), x.mean(axis=(1, 2)))
+    assert_eq(a.max(axis=(1, 2)), x.max(axis=(1, 2)))
+
+
 def test_add_many_sparse_arrays():
     x = COO({(1, 1): 1}, shape=(2, 2))
     y = sum([x] * 100)


### PR DESCRIPTION
## Summary

`_calc_counts_invidx` (`sparse/numba_backend/_coo/core.py`) casts its `inv_idx`/`counts`
arrays to `groups.dtype` — the dtype `sparse` picks to fit the array's *shape* (e.g. `int16`
for a dimension no bigger than a few hundred). But those two arrays are used as offsets into
the **nnz-length** data array via `np.add.reduceat`, which can be far larger than any single
shape dimension. Once `nnz` exceeds the dtype's max (32767 for `int16`), the offsets silently
wrap negative, and `COO.sum`/`.mean`/`.max`/etc. raise:

```
IndexError: index -32736 out-of-bounds in add.reduceat [0, 40000)
```

Minimal, 100%-public-API repro (no internal calls) — note `idx_dtype=np.int16` is a
legitimate, documented choice here since every shape dimension is small:

```python
import numpy as np, itertools, sparse

shape = (200, 20, 10)
coords = np.array(list(itertools.product(range(200), range(20), range(10)))).T
data = np.random.default_rng(0).random(coords.shape[1])

a = sparse.COO(coords, data, shape=shape, idx_dtype=np.int16)  # nnz = 40000 > int16 max
a.mean(axis=(1, 2))  # IndexError
```

### This isn't a contrived edge case — it happens with zero explicit dtype hints

I hit this in the wild via plain `pandas` + `xarray`, where nobody ever mentions `idx_dtype`.
`xarray.Dataset._set_sparse_data_from_dataframe` builds `COO` coords straight from a
`pandas.MultiIndex`'s codes:

```python
# xarray/core/dataset.py
coords = np.stack([np.asarray(code) for code in idx.codes], axis=0)
...
data = COO(coords, values, shape, has_duplicates=False, sorted=is_sorted, fill_value=fill_value)
```

`pandas.MultiIndex.codes` are themselves stored as `int8`/`int16`/`int32` depending on how
many distinct values each level has (pandas' own memory optimization) — so any moderately
large but not-huge parameter sweep naturally produces `int16` codes, with no `idx_dtype=`
anywhere in sight:

```python
import numpy as np, pandas as pd, xarray as xr

rng = np.random.default_rng(0)
n_seed, n_case = 200, 200
df = pd.DataFrame({
    "seed": np.tile(np.arange(n_seed), n_case),
    "case": np.repeat(np.arange(n_case), n_seed),
}).set_index(["seed", "case"])
s = pd.Series(rng.random(len(df)), index=df.index, name="val")

xa = xr.DataArray.from_series(s, sparse=True)  # no idx_dtype passed anywhere
print(xa.data.coords.dtype, xa.data.nnz)        # int16 40000
xa.mean("seed")                                 # IndexError, same as above
```

i.e. `sparse=True` + `xarray.DataArray.from_series`/`Dataset.from_dataframe` on an ordinary
multi-dimensional sweep with a few hundred distinct values per dimension is enough to trigger
this — a very common pattern for e.g. simulation/experiment result storage.

## Fix

Hardcode `int64` for `inv_idx`/`counts` instead of reusing `groups.dtype`. These two arrays
are transient — only used as index arguments to `reduceat`/fancy-indexing — and never stored
on the `COO` object, so the memory-saving rationale for a narrow dtype doesn't apply to them.

## Test plan

- [x] Added `test_reduce_narrow_idx_dtype` (next to the existing `test_large_sum`), which
      fails with the exact `IndexError` above on `main` and passes with the fix.
- [x] Confirmed via the same reproduction against the latest PyPI release (0.19.0), so this
      isn't specific to an in-progress refactor.
- [x] Confirmed the `pandas`/`xarray` real-world trigger path above independently reproduces
      the same error, unpatched, with no explicit `idx_dtype` anywhere in user code.
- [x] Ran the full `sparse/numba_backend/tests/test_coo.py` suite (2849 passed) — no
      regressions.
- [x] `ruff check` / `ruff format --check` pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
