### PR TITLE
fix: don't let NaN fill_value poison reductions of fully-populated slices

### DIFF
--- a/sparse/numba_backend/_sparse_array.py
+++ b/sparse/numba_backend/_sparse_array.py
@@ -407,10 +407,15 @@ class SparseArray:
             missing_counts = counts != n_cols
             data[missing_counts] = method(data[missing_counts], self.fill_value, **kwargs)
         else:
-            data = method(
-                data,
-                reduce_super_ufunc(self.fill_value, n_cols - counts),
-            ).astype(data.dtype)
+            n_fill = n_cols - counts
+            contribution = reduce_super_ufunc(self.fill_value, n_fill)
+            if method.identity is not None:
+                # Positions with no fill-value contribution (n_fill == 0) must reduce
+                # to the ufunc's identity, not `reduce_super_ufunc(fill_value, 0)`:
+                # e.g. `nan * 0 == nan`, even though 0 is the correct (identity)
+                # contribution of "no missing/fill elements" to a sum.
+                contribution = np.where(n_fill == 0, method.identity, contribution)
+            data = method(data, contribution).astype(data.dtype)
             result_fill_value = reduce_super_ufunc(self.fill_value, n_cols)
 
         out = self._reduce_return(data, arr_attrs, result_fill_value)

--- a/sparse/numba_backend/_sparse_array.py
+++ b/sparse/numba_backend/_sparse_array.py
@@ -408,7 +408,10 @@ class SparseArray:
             data[missing_counts] = method(data[missing_counts], self.fill_value, **kwargs)
         else:
             n_fill = n_cols - counts
-            contribution = reduce_super_ufunc(self.fill_value, n_fill)
+            with np.errstate(invalid="ignore"):
+                # Suppresses spurious "invalid value" warnings from e.g. `nan * 0`
+                # below, for entries the following `np.where` discards anyway.
+                contribution = reduce_super_ufunc(self.fill_value, n_fill)
             if method.identity is not None:
                 # Positions with no fill-value contribution (n_fill == 0) must reduce
                 # to the ufunc's identity, not `reduce_super_ufunc(fill_value, 0)`:

--- a/sparse/numba_backend/tests/test_coo.py
+++ b/sparse/numba_backend/tests/test_coo.py
@@ -165,6 +165,24 @@ def test_nan_reductions(reduction, axis, keepdims, fraction):
     assert_eq(expected, actual)
 
 
+@pytest.mark.parametrize("reduction", ["sum", "mean"])
+@pytest.mark.parametrize("axis", [None, 0, 1])
+def test_reduction_nan_fill_value(reduction, axis):
+    # Regression test: a NaN `fill_value` must not poison reduction results for
+    # positions/slices that have no implicit (fill) elements contributing to them.
+    # `reduce_super_ufunc(fill_value, n_fill)` (e.g. `fill_value * n_fill` for `sum`)
+    # must use the ufunc's identity when `n_fill == 0`, since e.g. `nan * 0 == nan`
+    # even though 0 is the correct contribution of "no missing elements".
+    coords = [[0, 0, 1, 1, 2, 2], [0, 1, 0, 1, 0, 1]]
+    data = [0.586, 0.021, np.nan, 0.156, 0.363, 0.281]
+    s = COO(coords, data, shape=(3, 2), fill_value=np.nan)
+    x = s.todense()
+
+    expected = getattr(np, reduction)(x, axis=axis)
+    actual = getattr(s, reduction)(axis=axis)
+    assert_eq(expected, actual)
+
+
 @pytest.mark.parametrize("reduction", ["nanmax", "nanmin", "nanmean"])
 @pytest.mark.parametrize("axis", [None, 0, 1])
 def test_all_nan_reduction_warning(reduction, axis):


### PR DESCRIPTION
## Summary

`SparseArray.reduce()` (used by `sum`/`mean`/etc.) computes each output position's
contribution from implicit fill elements as `reduce_super_ufunc(fill_value, n_fill)`
(e.g. `fill_value * n_fill` for `sum`/`add`, via the `add -> multiply` entry in
`_reduce_super_ufunc`). When a position has **no** fill elements at all
(`n_fill == 0`), this contribution should be the ufunc's identity (`0` for `add`),
but `nan * 0 == nan`. So any `sum`/`mean` reduction over an array with
`fill_value=nan` turns *every* output position into NaN as soon as *any single
element anywhere in the array* is missing/NaN along the reduced axis — even
positions/slices that are fully populated with real data.

This is easy to hit via `xarray.DataArray.from_series(series, sparse=True)` on
ragged/incomplete multi-index data (a common pattern for irregular experiment
grids), since that produces `fill_value=nan` for float data, and
`skill.mean(dim, skipna=False)` then silently collapses the whole result to
all-NaN (`nnz == 0`) instead of only NaNing the incomplete slices.

`prod`/`multiply` reductions are unaffected: their identity `1` is also
correctly given by `fill_value ** 0` for any fill_value, including NaN, since
`pow(x, 0) == 1` unconditionally per IEEE 754 — it's specifically `add`'s
`x * 0 == 0` identity that breaks down for non-finite `fill_value`.

### Repro

```python
import numpy as np
import sparse

coords = [[0, 0, 1, 1, 2, 2], [0, 1, 0, 1, 0, 1]]
data = [0.586, 0.021, np.nan, 0.156, 0.363, 0.281]
s = sparse.COO(coords, data, shape=(3, 2), fill_value=np.nan)
print(s.todense())
# [[0.586 0.021]
#  [  nan 0.156]
#  [0.363 0.281]]

print(s.sum(axis=0).todense())
# before: [nan nan]        (column 1 has no missing values at all!)
# after:  [nan 0.458]      (matches s.todense().sum(axis=0))
```

## How this regressed

- #237 originally reported that `sum()` raised `ValueError: ... would produce a
  dense result` for any non-zero (non-"absorbing") `fill_value`, e.g. `(s + 1).sum()`.
- #238 ("Support reduce fill_value in specific cases") introduced the
  `_reduce_super_ufunc` machinery (`add -> multiply`, `multiply -> power`) to
  handle this correctly for finite fill values, but deliberately *gated* it:
  the generalized formula was only used `if not equivalent(zero_reduce_result,
  self.fill_value)` — i.e. only when the fill_value doesn't already reduce to
  itself (self-absorbing) under the operation. When it *is* self-absorbing
  (`0` for `add`, and — since `equivalent()` treats any NaN as equivalent to
  any other NaN — also `nan` for `add`, since `nan + nan` is "equivalent" to
  `nan`), the old code fell back to a simpler, per-position direct-application
  path that never hits the `x * 0` edge case at all.
- #691 ("Expand Array API coverage for Numba backend"), aiming to broaden
  Array API standard compliance, refactored this gate so `reduce_super_ufunc`
  is now looked up unconditionally (only the *error* is still gated on
  `equivalent(...)`), rather than only being computed when actually needed.
  That made the generalized (but NaN/inf-unsafe) formula the *only* path taken
  for `add`/`multiply` reductions, silently dropping the previously-safe
  per-position fallback for self-absorbing fill values like NaN. This landed
  in the `0.16.0` release line — I bisected `0.15.4` (correct) against
  `0.16.0` (broken) down to this exact commit.

Neither #238 nor #691 intended to change behavior for NaN-fill-value arrays;
the regression is a side effect of generalizing the reduction formula without
re-deriving the identity-element special case that the old gated branch had
implicitly (and only accidentally, for the `add`/NaN combination) handled for free.

## Why this fix (and not reverting to the old gate)

The generalized formula (`fill_value` raised/multiplied by `n_fill`) is the
mathematically correct way to fold `n_fill` implicit copies of `fill_value`
into a reduction, and is still needed for #238's original "specific cases"
(e.g. `fill_value=1` for `sum`). The bug is *only* that it disagrees with the
identity element specifically at `n_fill == 0`, for fill values that aren't
"well-behaved" under the ufunc at zero multiplicity (`nan`, `+inf`, `-inf` for
`add`; none exist for `multiply`, since `pow(x, 0) == 1` always). So rather
than reinstating the old gated dual-path (which would silently reintroduce a
*different* class of subtle bugs whenever `equivalent()`'s notion of
"self-absorbing" doesn't match "well-behaved at n_fill == 0"), this patches
the general formula at exactly that boundary, for both branches:

Verified by hand (in addition to the added test) that this — not just NaN —
also fixes/preserves correctness for `fill_value` of `+inf`, `-inf`, `1`
(the original #238 case), and `0` (the default), across `axis in [None, 0, 1]`
and `keepdims in [False, True]`, all matching dense NumPy results exactly.

## Fix

Substitute `method.identity` whenever `n_fill == 0`, instead of computing
`reduce_super_ufunc(fill_value, 0)`. Also wrap the (now partially-discarded)
`reduce_super_ufunc(fill_value, n_fill)` call in `np.errstate(invalid="ignore")`,
since e.g. `nan * 0` still computes (and would otherwise warn) before being
overwritten by `np.where` for the `n_fill == 0` entries.

## Test plan

- Added `test_reduction_nan_fill_value` in `test_coo.py` (parametrized over
  `sum`/`mean` and `axis in [None, 0, 1]`); confirmed it fails without the fix
  and passes with it.
- Full `sparse/numba_backend/tests/` suite (excluding `test_dask_interop.py`,
  which fails to collect in this environment for unrelated reasons — `dask`
  isn't installed): 6065 passed, 0 failed.
- Manually verified (see above) `fill_value in {nan, +inf, -inf, 1, 0}` all
  match dense NumPy across `axis in [None, 0, 1]` x `keepdims in [False, True]`,
  and that no `RuntimeWarning` is emitted (ran with
  `-W error::RuntimeWarning`).
- `ruff check` / `ruff format --diff`: clean.